### PR TITLE
Add support for multi-channel Zigbee device

### DIFF
--- a/cli/cmd/zigbee/firmware/build.go
+++ b/cli/cmd/zigbee/firmware/build.go
@@ -40,7 +40,10 @@ func buildFirmware(ctx *cli.Context) error {
 		workDir = "."
 	}
 
-	generator := generate.NewGenerator(cfg)
+	generator, err := generate.NewGenerator(cfg)
+	if err != nil {
+		return fmt.Errorf("new generator: %w", err)
+	}
 
 	if err := generator.Generate(workDir, cfg); err != nil {
 		return fmt.Errorf("generate base: %w", err)

--- a/cli/config/device.go
+++ b/cli/config/device.go
@@ -30,6 +30,9 @@ type General struct {
 	// Zephyr name for the board
 	Board    string
 	RunEvery time.Duration
+	// ZigbeeChannels will define which endpoints device should try to use.
+	// By default device will try all available channels.
+	ZigbeeChannels []int `yaml:"zigbee_channels"`
 	// Flasher defines the way the board should be flashed.
 	Flasher        string
 	FlasherOptions map[string]any

--- a/cli/types/appconfig/known.go
+++ b/cli/types/appconfig/known.go
@@ -26,11 +26,12 @@ var (
 	CONFIG_DK_LIBRARY = NewValue("CONFIG_DK_LIBRARY").Default(Yes)
 
 	// Zigbee
-	CONFIG_ZIGBEE                 = NewValue("CONFIG_ZIGBEE").Default(Yes)
-	CONFIG_ZIGBEE_APP_UTILS       = NewValue("CONFIG_ZIGBEE_APP_UTILS").Default(Yes)
-	CONFIG_ZIGBEE_CHANNEL         = NewValue("CONFIG_ZIGBEE_CHANNEL").Default(`11`)
-	CONFIG_ZIGBEE_ROLE_END_DEVICE = NewValue("CONFIG_ZIGBEE_ROLE_END_DEVICE").Default(Yes)
-	CONFIG_ZIGBEE_ROLE_ROUTER     = NewValue("CONFIG_ZIGBEE_ROLE_ROUTER").Default(Yes)
+	CONFIG_ZIGBEE                              = NewValue("CONFIG_ZIGBEE").Default(Yes)
+	CONFIG_ZIGBEE_APP_UTILS                    = NewValue("CONFIG_ZIGBEE_APP_UTILS").Default(Yes)
+	CONFIG_ZIGBEE_CHANNEL_MASK                 = NewValue("CONFIG_ZIGBEE_CHANNEL_MASK").Default("0x7FFF800")
+	CONFIG_ZIGBEE_ROLE_END_DEVICE              = NewValue("CONFIG_ZIGBEE_ROLE_END_DEVICE").Default(Yes)
+	CONFIG_ZIGBEE_ROLE_ROUTER                  = NewValue("CONFIG_ZIGBEE_ROLE_ROUTER").Default(Yes)
+	CONFIG_ZIGBEE_CHANNEL_SELECTION_MODE_MULTI = NewValue("CONFIG_ZIGBEE_CHANNEL_SELECTION_MODE_MULTI").Default(Yes)
 
 	// Cryptography
 	CONFIG_CRYPTO               = NewValue("CONFIG_CRYPTO").Default(Yes)

--- a/cli/zigbee.yml
+++ b/cli/zigbee.yml
@@ -17,6 +17,11 @@ general:
   #ncs_toolchain_base: ~/toolchains/7795df4459/
   #zephyr_base: ~/ncs/zephyr
 
+  # zigbee_channels will provide optional list of channels to use.
+  # Note: if not defined device will use all available channels,
+  # so it is not needed to define this if not specifically necessary.
+  zigbee_channels: [11,13,15,16,17]
+
   # Flasher tells which flashing method to use.
   # Currently `nrfutil`, `mcuboot` and `west`
   # are defined(but not equally tested). Nrfutil works though.


### PR DESCRIPTION
By default device will use all channels,
but can be limited down with a config option.