### PR TITLE
Fix firmware build

### DIFF
--- a/cli/cmd/zigbee/firmware/build.go
+++ b/cli/cmd/zigbee/firmware/build.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/ffenix113/zigbee_home/cli/config"
 	"github.com/ffenix113/zigbee_home/cli/generate"
@@ -35,7 +36,10 @@ func buildFirmware(ctx *cli.Context) error {
 	}
 
 	// Will work in the future.
-	workDir := ctx.String("workdir")
+	workDir, err := filepath.Abs(ctx.String("workdir"))
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
 	if workDir == "" {
 		workDir = "."
 	}

--- a/cli/runner/cmd.go
+++ b/cli/runner/cmd.go
@@ -98,6 +98,10 @@ func extendEnv(ncsToolchainPath string, zephyrPath string) []string {
 		"/usr/bin",
 		"/usr/local/bin",
 		"/opt/bin",
+		"/opt/nanopb/generator-bin",
+		"/opt/zephyr-sdk/aarch64-zephyr-elf/bin",
+		"/opt/zephyr-sdk/x86_64-zephyr-elf/bin",
+		"/opt/zephyr-sdk/arm-zephyr-eabi/bin",
 	})
 
 	envPath := os.Getenv("PATH")
@@ -106,12 +110,24 @@ func extendEnv(ncsToolchainPath string, zephyrPath string) []string {
 		combinedPath += ":" + envPath
 	}
 
+	pythonPath := generateEnvArray(ncsToolchainPath, []string{
+		"/usr/local/lib/python3.8",
+		"/usr/local/lib/python3.8/site-packages",
+	})
+
 	ldLibraryPath := generateEnvArray(ncsToolchainPath, []string{
-        "/usr/local/lib/",
+		"/usr/lib",
+		"/usr/lib/x86_64-linux-gnu",
+		"/usr/local/lib",
 	})
 
 	return []string{
 		"PATH=" + combinedPath,
+		"ZEPHYR_BASE=" + zephyrPath,
+		"ZEPHYR_SDK_INSTALL_DIR=" + path.Join(ncsToolchainPath, "/opt/zephyr-sdk"),
+		"ZEPHYR_TOOLCHAIN_VARIANT=zephyr",
+		"PYTHOHOME=" + path.Join(ncsCombinedPath, "/usr/local"),
+		"PYTHONPATH=" + pythonPath,
 		"LD_LIBRARY_PATH=" + ldLibraryPath,
 	}
 }

--- a/cli/runner/cmd.go
+++ b/cli/runner/cmd.go
@@ -98,10 +98,6 @@ func extendEnv(ncsToolchainPath string, zephyrPath string) []string {
 		"/usr/bin",
 		"/usr/local/bin",
 		"/opt/bin",
-		"/opt/nanopb/generator-bin",
-		"/opt/zephyr-sdk/aarch64-zephyr-elf/bin",
-		"/opt/zephyr-sdk/x86_64-zephyr-elf/bin",
-		"/opt/zephyr-sdk/arm-zephyr-eabi/bin",
 	})
 
 	envPath := os.Getenv("PATH")
@@ -110,24 +106,12 @@ func extendEnv(ncsToolchainPath string, zephyrPath string) []string {
 		combinedPath += ":" + envPath
 	}
 
-	pythonPath := generateEnvArray(ncsToolchainPath, []string{
-		"/usr/local/lib/python3.8",
-		"/usr/local/lib/python3.8/site-packages",
-	})
-
-	ldLibraryPath := generateEnvArray(ncsCombinedPath, []string{
-		"/usr/lib",
-		"/usr/lib/x86_64-linux-gnu",
-		"/usr/local/lib",
+	ldLibraryPath := generateEnvArray(ncsToolchainPath, []string{
+        "/usr/local/lib/",
 	})
 
 	return []string{
 		"PATH=" + combinedPath,
-		"ZEPHYR_BASE=" + zephyrPath,
-		"ZEPHYR_SDK_INSTALL_DIR=" + path.Join(ncsToolchainPath, "/opt/zephyr-sdk"),
-		"ZEPHYR_TOOLCHAIN_VARIANT=zephyr",
-		"PYTHOHOME=" + path.Join(ncsCombinedPath, "/usr/local"),
-		"PYTHONPATH=" + pythonPath,
 		"LD_LIBRARY_PATH=" + ldLibraryPath,
 	}
 }


### PR DESCRIPTION
Tested on v2.6.0 nRF Connect SDK, on a Debian 12.
I think workdir in cli/cmd/zigbee/firmware/build.go should be an absolute path.
Remove useless environment variables in cli/runner/cmd.go and fix ldLibraryPath.
Not sure it will work out of my setup.