### PR TITLE
Add DHT sensor

### DIFF
--- a/docs/sensors/supported_sensors.md
+++ b/docs/sensors/supported_sensors.md
@@ -10,4 +10,5 @@ When this change will be done - all sensors officially supported by Zephyr, will
     Full per-sensor options will be defined later. For now please refer to [configuration file](../using_the_cli/configuration_file.md) documentation or [latest configuration](https://github.com/ffenix113/zigbee_home/blob/develop/zigbee.yml) in repository for sensor configuration options.
 
 * `bme280` & `bme680` - Bosch BME280 / BME680
+* `dht` - Aosong DHT11 / DHT22 / AM2302
 * `scd4x` - Sensirion SCD41 ([driver](https://github.com/nobodyguy/sensirion_zephyr_drivers) by [nobodyguy](https://github.com/nobodyguy))

--- a/examples/sensor_dht/README.md
+++ b/examples/sensor_dht/README.md
@@ -1,0 +1,3 @@
+## A board with Aosong DHT sensor attached
+
+Simple example with one DHT sensor attached and using 1-wire interface (GPIO).

--- a/examples/sensor_dht/zigbee.yaml
+++ b/examples/sensor_dht/zigbee.yaml
@@ -1,0 +1,13 @@
+general:
+  board: nrf52840dongle_nrf52840
+
+board:
+
+sensors:
+  # Add a dht sensor from aosong manufacturer
+  # If DHT22 or AM2302 is used, variant must be set to "dht22". DHT11 does not need variant.
+    - type: dht
+      variant: "dht22"
+      pin:
+        port: 1
+        pin: 13

--- a/sensor/aosong/dht.go
+++ b/sensor/aosong/dht.go
@@ -1,0 +1,86 @@
+package aosong
+
+import (
+	"fmt"
+
+	"github.com/ffenix113/zigbee_home/sensor/base"
+	"github.com/ffenix113/zigbee_home/templates/extenders"
+	"github.com/ffenix113/zigbee_home/types/appconfig"
+	dt "github.com/ffenix113/zigbee_home/types/devicetree"
+	"github.com/ffenix113/zigbee_home/types/generator"
+	"github.com/ffenix113/zigbee_home/zcl/cluster"
+	"github.com/ffenix113/zigbee_home/types"
+)
+
+type DHT struct {
+	*base.Base `yaml:",inline"`
+	Pin      types.Pin
+    Variant  string `yaml:"variant"`
+}
+
+func NewDHT() *DHT {
+	return &DHT{
+		Variant: "",
+	}
+}
+
+func (b DHT) String() string {
+	return "Aosong"
+}
+
+func (DHT) Clusters() cluster.Clusters {
+	return []cluster.Cluster{
+		cluster.Temperature{
+			MinMeasuredValue: -40,
+			MaxMeasuredValue: 80,
+			Tolerance:        1,
+		},
+        cluster.NewRelativeHumidity(0, 100),
+	}
+}
+
+func (b DHT) AppConfig() []appconfig.ConfigValue {
+	return []appconfig.ConfigValue{
+		appconfig.NewValue("CONFIG_GPIO").Required(appconfig.Yes),
+		appconfig.CONFIG_DHT.Required(appconfig.Yes),
+	}
+}
+
+func (b DHT) ApplyOverlay(tree *dt.DeviceTree) error {
+
+    pinctrlNode := tree.FindSpecificNode(dt.SearchByLabel(dt.NodeLabelPinctrl))
+	if pinctrlNode == nil {
+		return dt.ErrNodeNotFound(dt.NodeLabelPinctrl)
+	}
+
+    pinLabel := fmt.Sprintf("gpio%d %d (GPIO_PULL_UP | GPIO_ACTIVE_LOW)", b.Pin.Port, b.Pin.Pin)
+
+    props:= []dt.Property{
+        dt.NewProperty("compatible", dt.FromValue("aosong,dht")),
+        dt.NewProperty("status", dt.FromValue("okay")),
+        dt.NewProperty("dio-gpios", dt.Angled(dt.Label(pinLabel))),
+    }
+    // Add variant property only if Variant is not emtpy
+    // For dht22 or AM2302 devices the string "dht22;" must be added to device tree overlay
+    // See : https://docs.zephyrproject.org/latest/build/dts/api/bindings/sensor/aosong,dht.html
+    if b.Variant != "" {
+        props = append(props, dt.NewProperty(b.Variant, nil))
+    }
+
+    pinctrlNode.AddNodes(
+        &dt.Node{
+            Name:  "dht22",
+            Label: b.Label(),
+            Properties: props,
+        },
+    )
+
+	return nil
+}
+
+func (DHT) Extenders() []generator.Extender {
+	return []generator.Extender{
+		extenders.NewSensor(),
+		extenders.GPIO{},
+	}
+}

--- a/types/appconfig/known.go
+++ b/types/appconfig/known.go
@@ -47,6 +47,9 @@ var (
 	CONFIG_NET_IP_ADDR_CHECK = NewValue("CONFIG_NET_IP_ADDR_CHECK").Default(No)
 	CONFIG_NET_UDP           = NewValue("CONFIG_NET_UDP").Default(No)
 
+	// Sensors
+	CONFIG_DHT               = NewValue("CONFIG_DHT").Default(Yes)
+
 	// Debug
 	CONFIG_ZBOSS_HALT_ON_ASSERT        = NewValue("CONFIG_ZBOSS_HALT_ON_ASSERT").Default(Yes)
 	CONFIG_RESET_ON_FATAL_ERROR        = NewValue("CONFIG_RESET_ON_FATAL_ERROR").Default(No)

--- a/types/sensor/known.go
+++ b/types/sensor/known.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ffenix113/zigbee_home/sensor"
 	"github.com/ffenix113/zigbee_home/sensor/base"
 	"github.com/ffenix113/zigbee_home/sensor/bosch"
+	"github.com/ffenix113/zigbee_home/sensor/aosong"
 	"github.com/ffenix113/zigbee_home/sensor/sensirion"
 )
 
@@ -61,6 +62,9 @@ var knownSensors = map[string]func() Sensor{
 	// FIXME: It does not yet support IAQ measurements,
 	// and does not expose resistance to Zigbee.
 	"bme680": fromConstructor(bosch.NewBME680),
+
+    // Aosong
+    "dht": fromConstructor(aosong.NewDHT),
 
 	// Sensirion
 	"scd4x": fromType[*sensirion.SCD4X],

--- a/zigbee.yaml
+++ b/zigbee.yaml
@@ -126,6 +126,13 @@ sensors:
   #     port: 0
   #     pin: 6
   #     inverted: true
+  # Add a dht sensor from aosong manufacturer
+  # If DHT22 or AM2302 is used, variant must be set to "dht22". DHT11 does not need variant.
+  # - type: dht
+  #   variant: "dht22"
+  #   pin:
+  #     port: 1
+  #     pin: 13
   #
   # power_config uses ADC to measure positive voltage
   # on pin 0.04 and report it as a battery voltage.


### PR DESCRIPTION
This PR add support for DHT sensors from Aosong.
Tested with a AM2302 and nRF52840 Dongle .

I'm new to go, so there is ugly code in sensor/aosong/dht.go (see FIXME in the code) :
- Don't know how to allow multiple sensor in device tree
- Don't know how to manipulate device tree properly

