### PR TITLE
fix: do not include water content attributes multiple times

### DIFF
--- a/config/device.go
+++ b/config/device.go
@@ -131,7 +131,7 @@ func (g General) GetToochainsPath() (string, string) {
 		var err error
 		locations, err = FindNCSLocation(g.NCSToolChainBase, ncsVersion)
 		if err != nil {
-			log.Panicf("find ncs location: %s", err.Error())
+			log.Fatalf("find ncs location: %s", err.Error())
 		}
 
 		log.Printf("found toolchain version %q, requested version %q", locations.Version, ncsVersion)

--- a/templates/src/zigbee/water_content.tpl
+++ b/templates/src/zigbee/water_content.tpl
@@ -1,4 +1,5 @@
 {{ define "water_content_defines"}}
+{{ if (eq .Cluster.ID.ToName "soil_moisture") }}
 // ZCL spec 4.7.1.3
 #define ZB_ZCL_CLUSTER_ID_SOIL_MOISTURE (0x0408)
 
@@ -7,9 +8,11 @@
 
 #define ZB_ZCL_ATTR_SOIL_MOISTURE_VALUE_UNKNOWN (0xffff)
 
+{{end}}
 {{ end }}
 
 {{ define "water_content_attr_types"}}
+{{ if (eq .Cluster.ID.ToName "soil_moisture") }}
 void zb_zcl_soil_moisture_init_server()
 {
   zb_zcl_add_cluster_handlers(ZB_ZCL_CLUSTER_ID_SOIL_MOISTURE,
@@ -21,6 +24,7 @@ void zb_zcl_soil_moisture_init_server()
 
 #define ZB_ZCL_CLUSTER_ID_SOIL_MOISTURE_SERVER_ROLE_INIT zb_zcl_soil_moisture_init_server
 #define ZB_ZCL_CLUSTER_ID_SOIL_MOISTURE_CLIENT_ROLE_INIT (NULL)
+{{end}}
 {{end}}
 
 {{ define "water_content_attr_list" }}

--- a/zcl/cluster/cluster_ids.go
+++ b/zcl/cluster/cluster_ids.go
@@ -43,36 +43,39 @@
 
 package cluster
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type ID int
 
-func (id ID) ToZCL() (string, error) {
+func (id ID) ToName() (string, error) {
 	var value string
 
 	switch id {
 	case ID_BASIC:
-		value = "ZB_ZCL_CLUSTER_ID_BASIC"
+		value = "basic"
 	case ID_POWER_CONFIG:
-		value = "ZB_ZCL_CLUSTER_ID_POWER_CONFIG"
+		value = "power_config"
 	case ID_DEVICE_TEMP_CONFIG:
-		value = "ZB_ZCL_CLUSTER_ID_DEVICE_TEMP_CONFIG"
+		value = "device_temp_config"
 	case ID_IDENTIFY:
-		value = "ZB_ZCL_CLUSTER_ID_IDENTIFY"
+		value = "identify"
 	case ID_ON_OFF:
-		value = "ZB_ZCL_CLUSTER_ID_ON_OFF"
+		value = "on_off"
 	case ID_TEMP_MEASUREMENT:
-		value = "ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT"
+		value = "temp_measurement"
 	case ID_PRESSURE_MEASUREMENT:
-		value = "ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT"
+		value = "pressure_measurement"
 	case ID_REL_HUMIDITY_MEASUREMENT:
-		value = "ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT"
+		value = "rel_humidity_measurement"
 	case ID_CARBON_DIOXIDE:
-		value = "ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE"
+		value = "carbon_dioxide"
 	case ID_IAS_ZONE:
-		value = "ZB_ZCL_CLUSTER_ID_IAS_ZONE"
+		value = "ias_zone"
 	case ID_SOIL_MOISTURE_MEASUREMENT:
-		value = "ZB_ZCL_CLUSTER_ID_SOIL_MOISTURE"
+		value = "soil_moisture"
 	}
 
 	if value == "" {
@@ -80,6 +83,15 @@ func (id ID) ToZCL() (string, error) {
 	}
 
 	return value, nil
+}
+
+func (id ID) ToZCL() (string, error) {
+	clusterName, err := id.ToName()
+	if err != nil {
+		return "", err
+	}
+
+	return "ZB_ZCL_CLUSTER_ID_" + strings.ToUpper(clusterName), nil
 }
 
 const ID_BASIC ID = 0              // Basic cluster identifier.


### PR DESCRIPTION
As water measurement clusters now all use same definition - they also include the same attribute,
which results in duplicated definitions and failed build.