### PR TITLE
fix: ias zone using wrong endpoint

### DIFF
--- a/templates/src/extenders/sensors/ias_zone.tpl
+++ b/templates/src/extenders/sensors/ias_zone.tpl
@@ -10,16 +10,21 @@ static const struct gpio_dt_spec {{.Sensor.Pin.Label}} = GPIO_DT_SPEC_GET(DT_NOD
 #define ZBHOME_IAS_ZONE_TOP_LEVEL
 
 #define ZB_SCHEDULE_CALLBACK ZB_SCHEDULE_APP_CALLBACK
-void update_zone_status(zb_bufid_t bufid, bool status) {
+void update_zone_status(zb_bufid_t bufid, zb_uint16_t cb_data) {
 	// TODO: Probably this function needs to free bufid somewhere,
 	// but I am not sure if it is actually the case.
 	// Would need to double-check.
+
+	// Decode values from the argument.
+	bool status = cb_data & 1;
+	zb_uint8_t endpoint = cb_data >> 1;
+
 	switch (status) {
 	case true:
-		ZB_ZCL_IAS_ZONE_SET_BITS(bufid, 2, ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1);
+		ZB_ZCL_IAS_ZONE_SET_BITS(bufid, endpoint, ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1);
 		break;
 	case false:
-		ZB_ZCL_IAS_ZONE_CLEAR_BITS(bufid, 2, ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1);
+		ZB_ZCL_IAS_ZONE_CLEAR_BITS(bufid, endpoint, ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1);
 		break;
 	}
 }
@@ -29,9 +34,13 @@ void update_zone_status(zb_bufid_t bufid, bool status) {
 {{ define "button_changed"}}
 	button_status = has_button_changed(&{{.Sensor.Pin.Label}}, button_state, has_changed);
 	if (button_status.has_changed) {
+		// Pack data.
+		// Endpoint can be >127, so we can't pack it and state into single uint8.
+		zb_uint16_t data = {{.Endpoint}} << 1 | button_status.state;
+
 		/* Allocate output buffer and send on/off command. */
 		zb_ret_t zb_err_code = zb_buf_get_out_delayed_ext(
-			update_zone_status, button_status.state, 0);
+			update_zone_status, data, 0);
 		ZB_ERROR_CHECK(zb_err_code);
 	}
 {{end}}


### PR DESCRIPTION
Previously it was hardcoded(probably for dumb testing reasons), and now the endpoint is being passed as an argument.

Resolves https://github.com/ffenix113/zigbee_home/discussions/43#discussioncomment-9399471