### PR TITLE
feat!: better buttons usage & factory reset button support 

### DIFF
--- a/config/device.go
+++ b/config/device.go
@@ -41,12 +41,14 @@ type General struct {
 }
 
 type Board struct {
-	Bootloader *string
-	Debug      *extenders.DebugConfig
-	IsRouter   bool `yaml:"is_router"`
-	LEDs       []types.Pin
-	I2C        []extenders.I2CInstance
-	UART       []extenders.UARTInstance
+	Bootloader         *string
+	Debug              *extenders.DebugConfig
+	IsRouter           bool   `yaml:"is_router"`
+	FactoryResetButton string `yaml:"factory_reset_button"`
+	LEDs               types.PinWithIDSlice
+	Buttons            types.PinWithIDSlice
+	I2C                []extenders.I2CInstance
+	UART               []extenders.UARTInstance
 }
 
 func ParseFromFile(configPath string) (*Device, error) {
@@ -104,7 +106,7 @@ func (d *Device) UnmarshalYAML(node *yaml.Node) error {
 // PrependCommonClusters adds common device clusters as first endpoint.
 //
 // This allows to have dynamic set of common device clusters,
-// such as Identify(server), basic, poll controll, etc.
+// such as Identify(server), basic, poll control, etc.
 //
 // FIXME: It is mostly a "workaround" to simplify device endpoint generation.
 // While the solution is sound to me, the implementation of this function is questionable.
@@ -127,9 +129,11 @@ func (g General) GetToochainsPath() (string, string) {
 	}
 
 	var locations NCSLocation
+
 	if ncsToolchainPath == "" || zephyrPath == "" {
 		var err error
 		locations, err = FindNCSLocation(g.NCSToolChainBase, ncsVersion)
+
 		if err != nil {
 			log.Fatalf("find ncs location: %s", err.Error())
 		}
@@ -152,7 +156,7 @@ func resolveStringEnv(input string) string {
 	if strings.HasPrefix(input, "~/") {
 		userHome, err := os.UserHomeDir()
 		if err != nil {
-			panic(fmt.Sprintf("could not resolve user home dir: %s", err.Error()))
+			panic("could not resolve user home dir: " + err.Error())
 		}
 
 		input = strings.Replace(input, "~/", userHome+"/", 1)

--- a/examples/factory_reset/README.md
+++ b/examples/factory_reset/README.md
@@ -1,0 +1,16 @@
+## Factory reset button
+
+This example demonstrates how to set up custom factory reset button.
+
+To properly test this example the board should be connected to a Zigbee network, and then the factory reset procedure(see `Usage`) should be done.
+
+### Explanation
+Factory reset will allow device to "forget" current network and start searching for new network.
+
+For example when network was changed(encryption, channel, etc), but device still expects old network to be available. 
+This will result in a situation where device will never connect to a network that it has stored in its memory.
+
+### Usage
+
+To actually trigger factory reset the user must hold the factory reset button for at least 5 seconds.
+If debug & LEDs are enabled - LED for connection should then turn off and device automatically will start trying to connect to any open Zigbee networks.

--- a/examples/factory_reset/zigbee.yaml
+++ b/examples/factory_reset/zigbee.yaml
@@ -1,0 +1,17 @@
+general:
+  board: nrf52840dongle_nrf52840
+
+board:
+  # `btn1` is a reference to any button defined in `board.buttons` via its `id`.
+  factory_reset_button: btn1
+
+  buttons:
+      # This could be either button that already defined in the board(in that case `pin` definition can be omited, and specify only `id`),
+      # or user can define any custom pin to be a button. 
+      # For custom pin both `id` and `pin` must be defined.
+    - id: btn1
+      # For this example random pin 0.13 is chosen to be a button.
+      pin: 0.13
+      # `button0` is defined in board definition here: https://github.com/zephyrproject-rtos/zephyr/blob/453ab8a9a356acf475a965a777a370795effa255/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840.dts#L64
+      # User can choose any button from their board definition.
+    - id: button0

--- a/generate/generator.go
+++ b/generate/generator.go
@@ -151,7 +151,11 @@ func getExtenders(device *config.Device) ([]generator.Extender, error) {
 	}
 
 	if len(device.Board.LEDs) != 0 {
-		providedExtenders = append(providedExtenders, extenders.NewLEDs(device.Board.LEDs...))
+		providedExtenders = append(providedExtenders, extenders.NewLEDs(device.Board.LEDs.ToPins()...))
+	}
+
+	if len(device.Board.Buttons) != 0 {
+		providedExtenders = append(providedExtenders, extenders.NewButtons(device.Board.Buttons.ToPins()...))
 	}
 
 	return providedExtenders, nil

--- a/runner/cmd.go
+++ b/runner/cmd.go
@@ -127,7 +127,6 @@ func extendEnv(ncsToolchainPath string, zephyrPath string) []string {
 		"PATH=" + combinedPath,
 		"ZEPHYR_BASE=" + zephyrPath,
 		"ZEPHYR_SDK_INSTALL_DIR=" + path.Join(ncsToolchainPath, "/opt/zephyr-sdk"),
-		"ZEPHYR_TOOLCHAIN_VARIANT=zephyr",
 		"LD_LIBRARY_PATH=" + ldLibraryPath,
 	}
 }

--- a/sensor/base/ias_zone.go
+++ b/sensor/base/ias_zone.go
@@ -1,11 +1,6 @@
 package base
 
 import (
-	"github.com/ffenix113/zigbee_home/templates/extenders"
-	"github.com/ffenix113/zigbee_home/types"
-	"github.com/ffenix113/zigbee_home/types/appconfig"
-	"github.com/ffenix113/zigbee_home/types/devicetree"
-	"github.com/ffenix113/zigbee_home/types/generator"
 	"github.com/ffenix113/zigbee_home/zcl/cluster"
 )
 
@@ -17,7 +12,7 @@ func NewContact() *IASZone {
 
 type IASZone struct {
 	*Base    `yaml:",inline"`
-	Pin      types.Pin
+	Button   string              `yaml:"button"`
 	ZoneType cluster.IasZoneType `yaml:"zone_type"`
 }
 
@@ -29,31 +24,13 @@ func (*IASZone) Template() string {
 	return "sensors/ias_zone"
 }
 
-func (o *IASZone) Clusters() cluster.Clusters {
+func (z *IASZone) Clusters() cluster.Clusters {
 	// By default - be contact sensor for now.
-	if o.ZoneType == "" {
-		o.ZoneType = cluster.IasZoneContact
+	if z.ZoneType == "" {
+		z.ZoneType = cluster.IasZoneContact
 	}
 
 	return []cluster.Cluster{
-		cluster.IASZone{ZoneType: o.ZoneType},
-	}
-}
-
-func (*IASZone) AppConfig() []appconfig.ConfigValue {
-	return []appconfig.ConfigValue{
-		appconfig.NewValue("CONFIG_GPIO").Required(appconfig.Yes),
-	}
-}
-
-func (z *IASZone) ApplyOverlay(dt *devicetree.DeviceTree) error {
-	btn := devicetree.NewButton(z.Pin)
-	return btn.AttachSelf(dt)
-}
-
-func (z *IASZone) Extenders() []generator.Extender {
-	return []generator.Extender{
-		extenders.GPIO{},
-		extenders.NewButtons(),
+		cluster.IASZone{ZoneType: z.ZoneType},
 	}
 }

--- a/templates/extenders/buttons.go
+++ b/templates/extenders/buttons.go
@@ -2,6 +2,7 @@ package extenders
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/ffenix113/zigbee_home/types"
 	"github.com/ffenix113/zigbee_home/types/devicetree"
@@ -20,7 +21,7 @@ type Button struct {
 func NewButtons(instances ...types.Pin) generator.Extender {
 	for i := range instances {
 		if instances[i].ID == "" {
-			instances[i].ID = instances[i].Label()
+			log.Fatalf("button %#v must have an id set", instances[i])
 		}
 	}
 
@@ -29,16 +30,16 @@ func NewButtons(instances ...types.Pin) generator.Extender {
 	}
 }
 
-func (l Button) Template() string {
+func (b Button) Template() string {
 	return "peripherals/buttons"
 }
 
-func (l Button) Includes() []string {
+func (b Button) Includes() []string {
 	return []string{"zephyr/drivers/gpio.h"}
 }
 
-func (l Button) ApplyOverlay(dt *devicetree.DeviceTree) error {
-	for _, instance := range l.Instances {
+func (b Button) ApplyOverlay(dt *devicetree.DeviceTree) error {
+	for _, instance := range b.Instances {
 		ledInstance := devicetree.NewButton(instance)
 		if err := ledInstance.AttachSelf(dt); err != nil {
 			return fmt.Errorf("attach button: %w", err)

--- a/templates/src/device.h.tpl
+++ b/templates/src/device.h.tpl
@@ -9,10 +9,6 @@
 /* Weather check period */
 #define WEATHER_CHECK_PERIOD_MSEC {{.Device.General.RunEvery.Milliseconds}}
 
-/* Delay for first weather check */
-#define CONFIG_FIRST_WEATHER_CHECK_DELAY_SECONDS 5
-#define WEATHER_CHECK_INITIAL_DELAY_MSEC (1000 * CONFIG_FIRST_WEATHER_CHECK_DELAY_SECONDS)
-
 /* Time of LED on state while blinking for identify mode */
 #define IDENTIFY_LED_BLINK_TIME_MSEC 500
 
@@ -29,7 +25,9 @@
 #define IDENTIFY_LED LED_RED
 
 /* Button used to enter the Identify mode */
-#define IDENTIFY_MODE_BUTTON DK_BTN1_MSK
+#define IDENTIFY_MODE_BUTTON {{ if not (eq .Device.Board.FactoryResetButton "") -}}
+{{ toButtonBit .Device.Board.FactoryResetButton }}
+{{- else -}}DK_BTN1_MSK{{ end }}
 
 /* Button to start Factory Reset */
 #define FACTORY_RESET_BUTTON IDENTIFY_MODE_BUTTON

--- a/templates/src/extenders/peripherals/buttons.tpl
+++ b/templates/src/extenders/peripherals/buttons.tpl
@@ -2,6 +2,8 @@
 {{ define "top_level" }}
 {{- range .Extender.Instances }}
 static struct gpio_dt_spec {{.ID}} = GPIO_DT_SPEC_GET(DT_NODELABEL({{.ID}}), gpios);
+static const uint32_t {{ toButtonName .ID}} = {{ toButtonIdx .ID }};
+static const uint32_t {{ toButtonBitName .ID}} = {{ toButtonBit .ID }};
 {{- end }}
 {{end}}
 

--- a/templates/src/extenders/sensors/ias_zone.tpl
+++ b/templates/src/extenders/sensors/ias_zone.tpl
@@ -1,8 +1,4 @@
 {{ define "top_level" }}
-static const struct gpio_dt_spec {{.Sensor.Pin.Label}} = GPIO_DT_SPEC_GET(DT_NODELABEL({{.Sensor.Pin.Label}}), gpios);
-
-// TODO: Merge Button extender, for it to define necessary buttons.
-
 // For some reason ZB_SCHEDULE_CALLBACK is not defined with current setup,
 // and I can't find a necessary include/config to enable it.
 // So for now - re-define the callback as another callback.
@@ -32,11 +28,12 @@ void update_zone_status(zb_bufid_t bufid, zb_uint16_t cb_data) {
 {{ end }}
 
 {{ define "button_changed"}}
-	button_status = has_button_changed(&{{.Sensor.Pin.Label}}, button_state, has_changed);
-	if (button_status.has_changed) {
+	bool button_pressed = button_state & {{ toButtonBitName .Sensor.Button}};
+	bool button_changed = has_changed & {{ toButtonBitName .Sensor.Button}};
+	if (button_changed) {
 		// Pack data.
 		// Endpoint can be >127, so we can't pack it and state into single uint8.
-		zb_uint16_t data = {{.Endpoint}} << 1 | button_status.state;
+		zb_uint16_t data = {{.Endpoint}} << 1 | button_pressed;
 
 		/* Allocate output buffer and send on/off command. */
 		zb_ret_t zb_err_code = zb_buf_get_out_delayed_ext(

--- a/types/pin.go
+++ b/types/pin.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strconv"
 
@@ -9,6 +10,43 @@ import (
 )
 
 var _ yaml.Unmarshaler = (*Pin)(nil)
+
+// PinWithID is similar to Pin,
+// but the difference is that user can define ID & short Pin for this type.
+//
+// So insted of `{id: 'some', port: 0, pin: 1}`
+// user can provide `{id: 'some', pin: 0.04}`.
+//
+// Still, probably there is a more elegant way to achieve this.
+type PinWithID struct {
+	ID  string
+	Pin Pin
+}
+
+func (p PinWithID) ToPin() Pin {
+	if p.ID != "" && p.Pin.ID != "" {
+		// This log message can be improved
+		log.Fatalf("cannot have id & pin.id set at the same time for pin %#v", p)
+	}
+
+	if p.Pin.ID == "" {
+		p.Pin.ID = p.ID
+	}
+
+	return p.Pin
+}
+
+type PinWithIDSlice []PinWithID
+
+func (s PinWithIDSlice) ToPins() []Pin {
+	pins := make([]Pin, 0, len(s))
+
+	for _, pinWithID := range s {
+		pins = append(pins, pinWithID.ToPin())
+	}
+
+	return pins
+}
 
 type Pin struct {
 	ID       string


### PR DESCRIPTION
* Add `board.buttons` to define buttons on the board that will be re-used by other sensors/functions.
* Add support for `board.factory_reset_button` to specify which button will be used to trigger factory reset.
* Add factory reset example

BREAKING CHANGE: `contact` sensor now accepts `button` instead of `pin`.
`button` value must be referencing any of `board.buttons` defined buttons.