### PR TITLE
feat: connection led blink & strict yaml unmarshaling

### DIFF
--- a/config/device.go
+++ b/config/device.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"slices"
@@ -12,6 +13,7 @@ import (
 	"github.com/ffenix113/zigbee_home/templates/extenders"
 	"github.com/ffenix113/zigbee_home/types"
 	"github.com/ffenix113/zigbee_home/types/sensor"
+	"github.com/ffenix113/zigbee_home/types/yamlstrict"
 	"gopkg.in/yaml.v3"
 )
 
@@ -47,9 +49,12 @@ type Board struct {
 	FactoryResetButton string `yaml:"factory_reset_button"`
 	NetworkStateLED    string `yaml:"network_state_led"`
 	LEDs               types.PinWithIDSlice
-	Buttons            types.PinWithIDSlice
-	I2C                []extenders.I2CInstance
-	UART               []extenders.UARTInstance
+	// Buttons provide definitions(or references) to board buttons.
+	// They will be used in other configuration places to
+	// reference specific button.
+	Buttons types.PinWithIDSlice
+	I2C     []extenders.I2CInstance
+	UART    []extenders.UARTInstance
 }
 
 func ParseFromFile(configPath string) (*Device, error) {
@@ -65,26 +70,35 @@ func ParseFromFile(configPath string) (*Device, error) {
 
 	file, err := os.Open(configPath)
 	if err != nil {
-		return cfg, fmt.Errorf("read config file: %w", err)
+		return cfg, fmt.Errorf("open config file: %w", err)
 	}
 
 	defer file.Close()
 
-	dec := yaml.NewDecoder(file)
-	dec.KnownFields(true)
+	cfg, err = ParseFromReader(cfg, file)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal config file: %w", err)
+	}
 
-	if err := dec.Decode(cfg); err != nil {
-		return cfg, fmt.Errorf("unmarshal config: %w", err)
+	return cfg, nil
+}
+
+func ParseFromReader(defConfig *Device, rdr io.Reader) (*Device, error) {
+	dec := yaml.NewDecoder(rdr)
+	dec.KnownFields(false)
+
+	if err := dec.Decode(defConfig); err != nil {
+		return nil, fmt.Errorf("unmarshal config: %w", err)
 	}
 
 	// This may contain environment variables,
 	// so be kind and try to resolve
-	cfg.General.NCSToolChainBase = resolveStringEnv(cfg.General.NCSToolChainBase)
-	cfg.General.ZephyrBase = resolveStringEnv(cfg.General.ZephyrBase)
+	defConfig.General.NCSToolChainBase = resolveStringEnv(defConfig.General.NCSToolChainBase)
+	defConfig.General.ZephyrBase = resolveStringEnv(defConfig.General.ZephyrBase)
 
-	cfg.PrependCommonClusters()
+	defConfig.PrependCommonClusters()
 
-	return cfg, nil
+	return defConfig, nil
 }
 
 // UnamrshalYAML is implemented to intercept the original
@@ -97,7 +111,7 @@ func (d *Device) UnmarshalYAML(node *yaml.Node) error {
 
 	type dev Device
 
-	if err := node.Decode((*dev)(d)); err != nil {
+	if err := yamlstrict.Unmarshal((*dev)(d), node); err != nil {
 		return fmt.Errorf("unamrshal config: %w", err)
 	}
 

--- a/config/device.go
+++ b/config/device.go
@@ -45,6 +45,7 @@ type Board struct {
 	Debug              *extenders.DebugConfig
 	IsRouter           bool   `yaml:"is_router"`
 	FactoryResetButton string `yaml:"factory_reset_button"`
+	NetworkStateLED    string `yaml:"network_state_led"`
 	LEDs               types.PinWithIDSlice
 	Buttons            types.PinWithIDSlice
 	I2C                []extenders.I2CInstance

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigLoad(t *testing.T) {
+	t.Run("valid small", func(t *testing.T) {
+		data := []byte(`general: {board: some_board}`)
+
+		cfg, err := ParseFromReader(&Device{}, bytes.NewReader(data))
+		require.NoError(t, err)
+
+		require.NotNil(t, cfg)
+		require.Equal(t, "some_board", cfg.General.Board)
+	})
+
+	t.Run("invalid small", func(t *testing.T) {
+		data := []byte(`some: {unknown: some_board}`)
+
+		cfg, err := ParseFromReader(&Device{}, bytes.NewReader(data))
+		require.Error(t, err)
+		require.Nil(t, cfg)
+	})
+}
+
+// TestLoadExamples will try to load example configurations and check if they are valid.
+// It will not compile/generate them, only check if configuration is correct.
+//
+// In the future this should be replaced with actual building of the examples.
+func TestLoadExamples(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	examplesPath := path.Join(cwd, "..", "examples")
+	examples, err := os.ReadDir(examplesPath)
+	if err != nil {
+		t.Skipf("cannot read examples dir: %s", err.Error())
+	}
+
+	if len(examples) == 0 {
+		t.Skip("no example directories")
+	}
+
+	for _, example := range examples {
+		if !example.IsDir() {
+			continue
+		}
+
+		t.Run(example.Name(), func(t *testing.T) {
+			examplePath := path.Join(examplesPath, example.Name())
+			// We need to change directory as some files can contain includes,
+			// which will be relative to the configuration file.
+			require.NoError(t, os.Chdir(examplePath))
+
+			defaultConfig, err := os.Open(path.Join(examplePath, "zigbee.yaml"))
+			if errors.Is(err, os.ErrNotExist) {
+				t.Skip("default config not found")
+			}
+
+			require.NoError(t, err)
+
+			defer defaultConfig.Close()
+
+			_, err = ParseFromReader(&Device{}, defaultConfig)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/examples/contact/README.md
+++ b/examples/contact/README.md
@@ -2,4 +2,4 @@
 
 This example provides definition for contact sensor. 
 
-Each time the state of the pin `0.04` will change - board will update coordinator to show the new value.
+Each time the state of the button `button0` will change - board will update coordinator to show the new value.

--- a/examples/contact/zigbee.yaml
+++ b/examples/contact/zigbee.yaml
@@ -1,6 +1,10 @@
 general:
   board: nrf52840dongle_nrf52840
 
+board:
+  buttons:
+    - id: button0
+
 sensors:
   - type: contact
-    pin: 0.04
+    button: button0

--- a/templates/extenders/debug_log.go
+++ b/templates/extenders/debug_log.go
@@ -64,6 +64,12 @@ func NewDebugUARTLog(config DebugConfig) generator.Extender {
 			appconfig.NewValue("CONFIG_DEBUG_OPTIMIZATIONS").Default(appconfig.Yes),
 			appconfig.NewValue("CONFIG_DEBUG_THREAD_INFO").Default(appconfig.Yes),
 			appconfig.NewValue("CONFIG_THREAD_NAME").Default(appconfig.Yes),
+
+			// Configurations for (hopefully) generating
+			// good address for addr2line on exception.
+			appconfig.NewValue("CONFIG_DEBUG_COREDUMP").Default(appconfig.Yes),
+			appconfig.NewValue("CONFIG_DEBUG_COREDUMP_BACKEND_LOGGING").Default(appconfig.Yes),
+			appconfig.NewValue("CONFIG_COREDUMP_DEVICE").Default(appconfig.Yes),
 			// appconfig.NewValue("CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE").Default(`2048`),
 			// appconfig.NewValue("CONFIG_HEAP_MEM_POOL_SIZE").Default(`2048`),
 

--- a/templates/src/device.h.tpl
+++ b/templates/src/device.h.tpl
@@ -19,7 +19,9 @@
 #define LED_BLUE DK_LED4
 
 /* LED indicating that device successfully joined Zigbee network */
-#define ZIGBEE_NETWORK_STATE_LED LED_BLUE
+#define ZIGBEE_NETWORK_STATE_LED {{ if not (eq .Device.Board.NetworkStateLED "") -}}
+{{ toButtonBit .Device.Board.NetworkStateLED }}
+{{- else -}}LED_BLUE{{ end }}
 
 /* LED used for device identification */
 #define IDENTIFY_LED LED_RED

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -58,10 +58,6 @@ var knownExtenders = [...]string{
 }
 
 type Templates struct {
-	// Device is included in struct so it will not be required
-	// as argument in helper function(s).
-	device *config.Device
-
 	templates    *template.Template
 	templateTree templateTree
 }

--- a/types/devicetree/adc_pin.go
+++ b/types/devicetree/adc_pin.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ffenix113/zigbee_home/types"
+	"github.com/ffenix113/zigbee_home/types/yamlstrict"
 	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 )
@@ -73,7 +74,7 @@ func (p *ADCPin) UnmarshalYAML(node *yaml.Node) error {
 	} else {
 		type a ADCPin
 
-		if err := node.Decode((*a)(p)); err != nil {
+		if err := yamlstrict.Unmarshal((*a)(p), node); err != nil {
 			return fmt.Errorf("decode adc pin: %w", err)
 		}
 	}

--- a/types/option.go
+++ b/types/option.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 
+	"github.com/ffenix113/zigbee_home/types/yamlstrict"
 	"gopkg.in/yaml.v3"
 )
 
@@ -53,7 +54,7 @@ func (o Option[T]) Format(f fmt.State, verb rune) {
 func (o *Option[T]) UnmarshalYAML(n *yaml.Node) error {
 	var val T
 
-	if err := n.Decode(&val); err != nil {
+	if err := yamlstrict.Unmarshal(&val, n); err != nil {
 		return fmt.Errorf("unmarshal option with type %T: %w", val, err)
 	}
 

--- a/types/pin.go
+++ b/types/pin.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/ffenix113/zigbee_home/types/yamlstrict"
 	"gopkg.in/yaml.v3"
 )
 
@@ -90,7 +91,7 @@ func (p *Pin) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind != yaml.ScalarNode {
 		// A trick to remove custom unmarshaling behavior.
 		type pin Pin
-		if err := value.Decode((*pin)(p)); err != nil {
+		if err := yamlstrict.Unmarshal((*pin)(p), value); err != nil {
 			return fmt.Errorf("unmarshal pin: %w", err)
 		}
 

--- a/types/sensor/sensor.go
+++ b/types/sensor/sensor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ffenix113/zigbee_home/types/appconfig"
 	"github.com/ffenix113/zigbee_home/types/devicetree"
 	"github.com/ffenix113/zigbee_home/types/generator"
+	"github.com/ffenix113/zigbee_home/types/yamlstrict"
 	"github.com/ffenix113/zigbee_home/zcl/cluster"
 	"gopkg.in/yaml.v3"
 )
@@ -84,7 +85,7 @@ func (s *Sensors) UnmarshalYAML(value *yaml.Node) error {
 
 func unmarshalSensor(node *yaml.Node) (Sensor, error) {
 	var sensorType base.SensorType
-	if err := node.Decode(&sensorType); err != nil {
+	if err := node.Decode(&sensorType); err != nil { //nolint:forbidigo // In this case we want specific subset of fields.
 		return nil, fmt.Errorf("get sensor type: %w", err)
 	}
 
@@ -94,7 +95,7 @@ func unmarshalSensor(node *yaml.Node) (Sensor, error) {
 	}
 
 	rVal := reflect.ValueOf(sensorConfigConstructor())
-	if err := node.Decode(rVal.Interface()); err != nil {
+	if err := yamlstrict.Unmarshal(rVal.Interface(), node); err != nil {
 		return nil, fmt.Errorf("decode sensor type %q: %w", sensorType.Type, err)
 	}
 

--- a/types/yamlstrict/unmarshal.go
+++ b/types/yamlstrict/unmarshal.go
@@ -1,0 +1,25 @@
+package yamlstrict
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Unmarshal(to any, node *yaml.Node) error {
+	marshaled, err := yaml.Marshal(node)
+	if err != nil {
+		return fmt.Errorf("marshaling node to bytes: %w", err)
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(marshaled))
+	dec.KnownFields(true)
+
+	err = dec.Decode(to)
+	if err != nil {
+		return fmt.Errorf("unmarshal strict: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
* [feat: blink when trying to connect to network](https://github.com/ffenix113/zigbee_home/commit/175dc56a0c84dcb1687820ef599193aa0da943d3)
Currently there is no reasonable identification if the device is trying to connect or not.
This will add a blinking led when device is trying to connect to network.

* [chore: do strict unmarshaling of configuration](https://github.com/ffenix113/zigbee_home/commit/467a574651254a10f49c3e191601062b98d0cd4f)
Unmarshaling of types that implement custom unmarshaling interface will not use that option,
which in case of this configuration will lead to basically loosing that setting.
https://github.com/go-yaml/yaml/issues/460
This change adds strict unmarshaling, though in not ideal way.
Also add test that tries to load example configurations as first test for their validity.