### PR TITLE
fix: do not blink if network LED is not defined

### DIFF
--- a/templates/src/main.c.tpl
+++ b/templates/src/main.c.tpl
@@ -53,6 +53,8 @@ LOG_MODULE_REGISTER(app, LOG_LEVEL_DBG);
 
 #define DEVICE_INITIAL_DELAY_MSEC 2000
 
+{{/* This check should be a helper really */}}
+{{- if not (eq .Device.Board.NetworkStateLED "") }}
 static void toggle_identify_led(uint16_t led_data)
 {
 	bool led_on = led_data & 1;
@@ -69,6 +71,7 @@ static void toggle_identify_led(uint16_t led_data)
 		LOG_ERR("Failed to schedule app alarm: %d", err);
 	}
 }
+{{- end }}
 
 static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
@@ -294,15 +297,19 @@ void zboss_signal_handler(zb_bufid_t bufid)
 		break;
 	case ZB_ZDO_SIGNAL_LEAVE:
 	case ZB_BDB_SIGNAL_DEVICE_FIRST_START:
+		{{ if not (eq .Device.Board.NetworkStateLED "") }}
 		// When leaving network - start blinking led.
 		ZB_SCHEDULE_APP_CALLBACK(toggle_identify_led, ZIGBEE_NETWORK_STATE_LED << 1 | 0);
+		{{ end }}
 		break;
 	case ZB_BDB_SIGNAL_STEERING:
+		{{ if not (eq .Device.Board.NetworkStateLED "") }}
 		ZB_SCHEDULE_APP_ALARM_CANCEL(toggle_identify_led,
 						   ZB_ALARM_ANY_PARAM);
 		// While we will stop blinking it does not mean that 
 		// the LED will be in off state on last iteration.
 		dk_set_led_off(ZIGBEE_NETWORK_STATE_LED);
+		{{ end }}
 		break;
 	default:
 		break;


### PR DESCRIPTION
While in general blinking LED is a good this to have to signal that device is trying to pair - in some boards this may not be an option.

If so - do not blink LED.

Potentially otherwise this could lead to some lock or kernel panic probably.