### PR TITLE
fix: be more understandable of path separators in templates

### DIFF
--- a/runner/cmd.go
+++ b/runner/cmd.go
@@ -113,6 +113,7 @@ func extendEnv(ncsToolchainPath string, zephyrPath string) []string {
 
 	envPath := os.Getenv("PATH")
 	combinedPath := ncsCombinedPath
+
 	if envPath != "" {
 		combinedPath += string(os.PathListSeparator) + envPath
 	}
@@ -127,6 +128,7 @@ func extendEnv(ncsToolchainPath string, zephyrPath string) []string {
 		"PATH=" + combinedPath,
 		"ZEPHYR_BASE=" + zephyrPath,
 		"ZEPHYR_SDK_INSTALL_DIR=" + path.Join(ncsToolchainPath, "/opt/zephyr-sdk"),
+		"ZEPHYR_TOOLCHAIN_VARIANT=zephyr",
 		"LD_LIBRARY_PATH=" + ldLibraryPath,
 	}
 }

--- a/templates/extenders/adc.go
+++ b/templates/extenders/adc.go
@@ -2,6 +2,7 @@ package extenders
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/ffenix113/zigbee_home/types/devicetree"
 	"github.com/ffenix113/zigbee_home/types/generator"
@@ -23,7 +24,7 @@ func NewADC(instances ...devicetree.ADCPin) generator.Extender {
 }
 
 func (l ADC) Template() string {
-	return "peripherals/adc"
+	return filepath.Join("peripherals", "adc")
 }
 
 func (l ADC) WriteFiles() []generator.WriteFile {

--- a/templates/extenders/buttons.go
+++ b/templates/extenders/buttons.go
@@ -3,6 +3,7 @@ package extenders
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 
 	"github.com/ffenix113/zigbee_home/types"
 	"github.com/ffenix113/zigbee_home/types/devicetree"
@@ -31,7 +32,7 @@ func NewButtons(instances ...types.Pin) generator.Extender {
 }
 
 func (b Button) Template() string {
-	return "peripherals/buttons"
+	return filepath.Join("peripherals", "buttons")
 }
 
 func (b Button) Includes() []string {

--- a/templates/extenders/leds.go
+++ b/templates/extenders/leds.go
@@ -2,6 +2,7 @@ package extenders
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/ffenix113/zigbee_home/types"
 	"github.com/ffenix113/zigbee_home/types/devicetree"
@@ -24,7 +25,7 @@ func NewLEDs(instances ...types.Pin) generator.Extender {
 }
 
 func (l LED) Template() string {
-	return "peripherals/leds"
+	return filepath.Join("peripherals", "leds")
 }
 
 func (l LED) Includes() []string {

--- a/templates/template_tree.go
+++ b/templates/template_tree.go
@@ -2,7 +2,7 @@ package templates
 
 import (
 	"fmt"
-	"strings"
+	"path/filepath"
 	"text/template"
 )
 
@@ -11,14 +11,12 @@ type templateTree struct {
 	tpl  *template.Template
 }
 
-func (t *templateTree) FindByPath(prefix string) []*template.Template {
-	parts := strings.Split(prefix, "/")
-
+func (t *templateTree) FindByPath(parts ...string) []*template.Template {
 	currentTree := t
 	for _, part := range parts {
 		currentTree = currentTree.tree[part]
 		if currentTree == nil {
-			panic(fmt.Sprintf("part %q of prefix %q is not present in template tree", part, prefix))
+			panic(fmt.Sprintf("part %q of prefix %q is not present in template tree", part, filepath.Join(parts...)))
 		}
 	}
 


### PR DESCRIPTION
This is not ultimate fix for Windows, as paths for SDKs are hardcoded currently, but it is a step in the right direction to support it.

Ref: https://github.com/ffenix113/zigbee_home/issues/70