### PR TITLE
chore: many improvements

### DIFF
--- a/cmd/zigbee/firmware/flash.go
+++ b/cmd/zigbee/firmware/flash.go
@@ -11,7 +11,9 @@ func flashCmd() *cli.Command {
 		Name:  "flash",
 		Usage: "flash the firmware",
 		Action: func(ctx *cli.Context) error {
-			cfg, err := parseConfig(ctx)
+			configFileName := getConfigFile(ctx)
+
+			cfg, err := parseConfig(configFileName)
 			if err != nil {
 				return fmt.Errorf("prepare config: %w", err)
 			}

--- a/cmd/zigbee/firmware/flasher/mcuboot.go
+++ b/cmd/zigbee/firmware/flasher/mcuboot.go
@@ -13,9 +13,10 @@ import (
 type MCUBoot struct{}
 
 func (MCUBoot) Flash(ctx context.Context, device *config.Device, workDir string) error {
+	toolchainsPath := device.General.GetToochainsPath()
 	opts := []runner.CmdOpt{
 		runner.WithWorkDir(workDir),
-		runner.WithToolchainPath(device.General.GetToochainsPath()),
+		runner.WithToolchainPath(toolchainsPath.NCS, toolchainsPath.Zephyr),
 	}
 
 	// 1. Sign the firmware

--- a/cmd/zigbee/firmware/flasher/west.go
+++ b/cmd/zigbee/firmware/flasher/west.go
@@ -21,10 +21,11 @@ func (w West) Flash(ctx context.Context, device *config.Device, workDir string) 
 		opts = append(opts, "--"+opt, fmt.Sprint(val))
 	}
 
+	toolchainsPath := device.General.GetToochainsPath()
 	return runner.NewCmd("west", opts...).Run(
 		ctx,
 		runner.WithWorkDir(workDir),
-		runner.WithToolchainPath(device.General.GetToochainsPath()),
+		runner.WithToolchainPath(toolchainsPath.NCS, toolchainsPath.Zephyr),
 	)
 }
 

--- a/config/device.go
+++ b/config/device.go
@@ -140,7 +140,7 @@ func (d *Device) PrependCommonClusters() {
 	d.Sensors = slices.Insert(d.Sensors, 0, sensor.Sensor(base.NewCommonDeviceClusters()))
 }
 
-func (g General) GetToochainsPath() (string, string) {
+func (g General) GetToochainsPath() NCSLocation {
 	// If env variables are defined - they have higher priority.
 	ncsToolchainPath := os.Getenv("NCS_TOOLCHAIN_BASE")
 	ncsVersion := os.Getenv("NCS_VERSION")
@@ -171,7 +171,11 @@ func (g General) GetToochainsPath() (string, string) {
 		zephyrPath = locations.Zephyr
 	}
 
-	return ncsToolchainPath, zephyrPath
+	return NCSLocation{
+		Version: locations.Version,
+		NCS:     ncsToolchainPath,
+		Zephyr:  zephyrPath,
+	}
 }
 
 func resolveStringEnv(input string) string {

--- a/config/ncs_finder.go
+++ b/config/ncs_finder.go
@@ -104,7 +104,9 @@ func mapVersions(toolchainItem toolchainTopLevelItem) map[string]string {
 	mapped := make(map[string]string, len(toolchainItem.Toolchains))
 
 	for _, toolchain := range toolchainItem.Toolchains {
-		mapped[toolchain.NCSVersions[0]] = toolchain.Identifier.BundleID
+		for _, version := range toolchain.NCSVersions {
+			mapped[version] = toolchain.Identifier.BundleID
+		}
 	}
 
 	return mapped

--- a/config/ncs_finder.go
+++ b/config/ncs_finder.go
@@ -7,13 +7,13 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
-	"strconv"
+
+	"github.com/ffenix113/zigbee_home/types"
 )
 
 type NCSLocation struct {
-	Version string
+	Version types.Semver
 	NCS     string
 	Zephyr  string
 }
@@ -70,12 +70,20 @@ func providePaths(ncsBase, version string, toolchainItem toolchainTopLevelItem) 
 		return NCSLocation{}, fmt.Errorf("no toolchain versions found in toolchain configuration path %q", toolchainConfigPath(ncsBase))
 	}
 
-	var availableVersions []string
+	var availableVersions []types.Semver
 	for version := range versionToIdentifier {
-		availableVersions = append(availableVersions, version)
+		parsed, err := types.ParseSemver(version)
+		if err != nil {
+			return NCSLocation{}, fmt.Errorf("parse semver %q: %w", version, err)
+		}
+
+		availableVersions = append(availableVersions, parsed)
 	}
 
-	sort.Strings(availableVersions)
+	// Sort versions in increasing order
+	sort.Slice(availableVersions, func(i, j int) bool {
+		return availableVersions[i].Compare(availableVersions[j]) == -1
+	})
 
 	log.Printf("requested toolchain version: %q, available versions: %v", version, availableVersions)
 
@@ -89,7 +97,17 @@ func providePaths(ncsBase, version string, toolchainItem toolchainTopLevelItem) 
 
 	// If directly requested version is not present - try to use latest from the same minor version.
 	if bundleID == "" {
-		version = selectVersion(version, availableVersions)
+		requiredVersion, err := types.ParseSemver(version)
+		if err != nil {
+			return NCSLocation{}, fmt.Errorf("parse required version %q: %w", version, err)
+		}
+
+		foundVersion, err := selectVersion(requiredVersion, availableVersions)
+		if err != nil {
+			return NCSLocation{}, fmt.Errorf("select version: %w", err)
+		}
+
+		version = foundVersion.String()
 		bundleID = versionToIdentifier[version]
 	}
 
@@ -97,7 +115,12 @@ func providePaths(ncsBase, version string, toolchainItem toolchainTopLevelItem) 
 		return NCSLocation{}, errors.New("required version was not found and no other suitable version is present")
 	}
 
-	return constructPaths(ncsBase, version, bundleID), nil
+	semver, err := types.ParseSemver(version)
+	if err != nil {
+		return NCSLocation{}, fmt.Errorf("parse found version %q: %w", version, err)
+	}
+
+	return constructPaths(ncsBase, semver, bundleID), nil
 }
 
 func mapVersions(toolchainItem toolchainTopLevelItem) map[string]string {
@@ -112,64 +135,27 @@ func mapVersions(toolchainItem toolchainTopLevelItem) map[string]string {
 	return mapped
 }
 
-type version [3]uint8
-
-var versionRegx = regexp.MustCompile(`^v(\d+)\.(\d+)(?:\.(\d+))?$`)
-
-func parseVersion(ver string) version {
-	match := versionRegx.FindStringSubmatch(ver)
-	if match == nil {
-		log.Fatalf("incorrect version %q", ver)
-	}
-
-	var result version
-	for i, part := range match[1:] {
-		if i == 2 && part == "" {
-			part = "0"
-		}
-
-		parsed, err := strconv.ParseUint(part, 10, 8)
-		if err != nil {
-			log.Fatalf("should not happen: bad part of the version: %q", part)
-		}
-
-		result[i] = uint8(parsed)
-	}
-
-	return result
-}
-
-func (v version) greaterOrEqual(other version) bool {
-	return v[0] == other[0] &&
-		v[1] == other[1] &&
-		v[2] >= other[2]
-}
-
-func selectVersion(requested string, available []string) string {
-	requestedVer := parseVersion(requested)
-
+func selectVersion(requested types.Semver, available []types.Semver) (types.Semver, error) {
 	foundIdx := -1
 	for i, availableVer := range available {
-		parsedAvailable := parseVersion(availableVer)
-
-		if parsedAvailable.greaterOrEqual(requestedVer) {
+		if availableVer.SameMajorMinor(requested) && availableVer.Compare(requested) > 0 {
 			foundIdx = i
-			requestedVer = parsedAvailable
+			requested = availableVer
 		}
 	}
 
 	if foundIdx == -1 {
-		return ""
+		return types.Semver{}, nil
 	}
 
-	return available[foundIdx]
+	return available[foundIdx], nil
 }
 
-func constructPaths(ncsBase, version, bundleID string) NCSLocation {
+func constructPaths(ncsBase string, version types.Semver, bundleID string) NCSLocation {
 	return NCSLocation{
 		Version: version,
 		NCS:     filepath.Join(ncsBase, "toolchains", bundleID),
-		Zephyr:  filepath.Join(ncsBase, version, "zephyr"),
+		Zephyr:  filepath.Join(ncsBase, version.String(), "zephyr"),
 	}
 }
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -1,0 +1,64 @@
+package examples
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ffenix113/zigbee_home/cmd/zigbee/firmware"
+	"github.com/ffenix113/zigbee_home/config"
+	"github.com/stretchr/testify/require"
+)
+
+// This test will just ensure that the firmwares can be generated.
+// It does not test that they are valid or can be built.
+//
+// Still, it is useful to see possible broken configurations,
+// validate that templates and required functions.
+func TestGenerateAllExamples(t *testing.T) {
+	cwdAbsPath, err := filepath.Abs(".")
+	require.NoError(t, err)
+
+	examples, err := os.ReadDir(cwdAbsPath)
+	require.NoError(t, err)
+
+	for _, example := range examples {
+		if !example.IsDir() {
+			continue
+		}
+
+		t.Run(example.Name(), func(t *testing.T) {
+			runExample(t, filepath.Join(cwdAbsPath, example.Name()))
+		})
+	}
+}
+
+func runExample(t *testing.T, exampleDir string) {
+	// FIXME: This is needed for config parser to
+	// resolve includes in config files.
+	os.Chdir(exampleDir)
+
+	tmpDir, err := os.MkdirTemp("", "zigbee_home_*")
+	require.NoError(t, err)
+
+	t.Logf("created %s for example %s", tmpDir, exampleDir)
+
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	configPath := filepath.Join(exampleDir, "zigbee.yaml")
+	// It is possible that examples would have some configuration
+	// with non-default configuration file name.
+	// If we will find this - skip such example.
+	if _, err := os.Stat(configPath); err != nil {
+		t.Skipf("skipping, as cannot access config file: %s", err.Error())
+	}
+
+	cfg, err := config.ParseFromFile(configPath)
+	require.NoError(t, err)
+
+	err = firmware.GenerateFirmwareFiles(context.Background(), tmpDir, false, cfg)
+	require.NoError(t, err)
+}

--- a/examples/sensor_scd4x/README.md
+++ b/examples/sensor_scd4x/README.md
@@ -1,0 +1,3 @@
+## A board with Sensirion SCD4X sensor attached via I2C
+
+Simple example with one SCD4X sensor attached and using I2C.

--- a/examples/sensor_scd4x/zigbee.yaml
+++ b/examples/sensor_scd4x/zigbee.yaml
@@ -1,0 +1,17 @@
+general:
+  board: nrf52840dongle_nrf52840
+
+board:
+  i2c:
+    # Only ID can be specified if interface is present in board configuration.
+    - id: i2c0
+
+sensors:
+  # Add a SCD4X sensor from Sensirion manufacturer.
+  - type: scd4x
+    i2c: 
+      id: i2c0
+    # This option is defined here:
+    # https://github.com/nobodyguy/sensirion_zephyr_drivers/blob/438ae62df66e9b1d638e0d4eb1c3cf6ad2ae449b/dts/bindings/sensor/sensirion%2Cscd4x.yaml#L51
+    # This parameter is optional and can be omitted.
+    temperature_offset: 2

--- a/examples/set_toolchain_version/README.md
+++ b/examples/set_toolchain_version/README.md
@@ -1,0 +1,14 @@
+## Set toolchain version
+
+User can provide specific toolchain version that should be used.
+
+By default, if it is not defined explicitely, the default version from
+toolchain configuration will be used.
+
+If version specified in the configuration file is not available - 
+next available patch version will be selected.
+
+Zigbee_home has default version of toolchain specified, 
+that will be selected if no other version is specified 
+in configuration file or environment. 
+This default version is defined in `config/device.go`. 

--- a/examples/set_toolchain_version/zigbee.yaml
+++ b/examples/set_toolchain_version/zigbee.yaml
@@ -1,0 +1,4 @@
+general:
+  board: nrf52840dongle_nrf52840
+  # We can force specific version of toolchain (if it is available).
+  ncs_version: v2.5.0

--- a/generate/generator.go
+++ b/generate/generator.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ffenix113/zigbee_home/config"
 	"github.com/ffenix113/zigbee_home/templates/extenders"
+	"github.com/ffenix113/zigbee_home/types"
 	"github.com/ffenix113/zigbee_home/types/appconfig"
 	"github.com/ffenix113/zigbee_home/types/board"
 	"github.com/ffenix113/zigbee_home/types/devicetree"
@@ -32,10 +33,15 @@ func NewGenerator(device *config.Device) (*Generator, error) {
 		return nil, fmt.Errorf("default app config: %w", err)
 	}
 
+	ncsVersion, err := types.ParseSemver(device.General.NCSVersion)
+	if err != nil {
+		return nil, fmt.Errorf("parse provided ncs version: %w", err)
+	}
+
 	return &Generator{
 		AppConfig:  appConfig,
 		DeviceTree: devicetree.NewDeviceTree(),
-		Source:     source.NewSource(),
+		Source:     source.NewSource(ncsVersion),
 	}, nil
 }
 

--- a/templates/src/zigbee/carbon_dioxide.tpl
+++ b/templates/src/zigbee/carbon_dioxide.tpl
@@ -36,7 +36,9 @@ typedef void * zb_voidp_t;
     ZB_ZCL_ATTR_CARBON_DIOXIDE_VALUE_ID, \
     ZB_ZCL_ATTR_TYPE_SINGLE, \
     ZB_ZCL_ATTR_ACCESS_READ_ONLY | ZB_ZCL_ATTR_ACCESS_REPORTING, \
+    {{ if not ncsVersionIs_2_5 -}}
     (ZB_UINT16_MAX), \
+    {{ end -}}
     (zb_voidp_t) data_ptr \
   }
 
@@ -45,7 +47,9 @@ typedef void * zb_voidp_t;
     ZB_ZCL_ATTR_CARBON_DIOXIDE_MIN_VALUE_ID, \
     ZB_ZCL_ATTR_TYPE_SINGLE, \
     ZB_ZCL_ATTR_ACCESS_READ_ONLY, \
+    {{ if not ncsVersionIs_2_5 -}}
     (ZB_UINT16_MAX), \
+    {{ end -}}
     (zb_voidp_t) data_ptr \
   }
 
@@ -54,7 +58,9 @@ typedef void * zb_voidp_t;
     ZB_ZCL_ATTR_CARBON_DIOXIDE_MAX_VALUE_ID, \
     ZB_ZCL_ATTR_TYPE_SINGLE, \
     ZB_ZCL_ATTR_ACCESS_READ_ONLY, \
+    {{ if not ncsVersionIs_2_5 -}}
     (ZB_UINT16_MAX), \
+    {{ end -}}
     (zb_voidp_t) data_ptr \
   }
 
@@ -63,7 +69,9 @@ typedef void * zb_voidp_t;
     ZB_ZCL_ATTR_CARBON_DIOXIDE_TOLERANCE_ID, \
     ZB_ZCL_ATTR_TYPE_SINGLE, \
     ZB_ZCL_ATTR_ACCESS_READ_ONLY, \
+    {{ if not ncsVersionIs_2_5 -}}
     (ZB_UINT16_MAX), \
+    {{ end -}}
     (zb_voidp_t) data_ptr \
   }
 

--- a/templates/src/zigbee/device_temperature.c.tpl
+++ b/templates/src/zigbee/device_temperature.c.tpl
@@ -26,7 +26,9 @@ typedef void * zb_voidp_t;
     ZB_ZCL_ATTR_DEVICE_TEMP_CONFIG_CURRENT_TEMPERATURE_ID, \
     ZB_ZCL_ATTR_TYPE_U16, \
     ZB_ZCL_ATTR_ACCESS_READ_ONLY, \
+    {{ if not ncsVersionIs_2_5 -}}
     (ZB_UINT16_MAX), \
+    {{ end -}}
     (zb_voidp_t) data_ptr \
   }
 

--- a/types/semver.go
+++ b/types/semver.go
@@ -1,0 +1,82 @@
+package types
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+type Semver [3]uint8
+
+var versionRegx = regexp.MustCompile(`^v?(\d+)\.(\d+)(?:\.(\d+))?$`)
+
+func NewSemver(major, minor, patch uint8) Semver {
+	return Semver{major, minor, patch}
+}
+
+func ParseSemver(ver string) (Semver, error) {
+	match := versionRegx.FindStringSubmatch(ver)
+	if match == nil {
+		return Semver{}, fmt.Errorf("incorrect version %q", ver)
+	}
+
+	parsePart := func(part string) (uint8, error) {
+		if part == "" {
+			return 0, nil
+		}
+
+		parsed, err := strconv.ParseUint(part, 10, 8)
+		if err != nil {
+			return 0, fmt.Errorf("should not happen: bad part of the version: %q", part)
+		}
+
+		return uint8(parsed), nil
+	}
+
+	var parsed [3]uint8
+	for i, part := range match[1:] {
+		uintPart, err := parsePart(part)
+		if err != nil {
+			return Semver{}, fmt.Errorf("parse part %q: %w", part, err)
+		}
+		parsed[i] = uintPart
+	}
+
+	return Semver{parsed[0], parsed[1], parsed[2]}, nil
+}
+
+func (s Semver) String() string {
+	return fmt.Sprintf("v%d.%d.%d", s[0], s[1], s[2])
+}
+
+// SameMajorMinor checks if major and minor versions are equal.
+func (s Semver) SameMajorMinor(another Semver) bool {
+	return s[0] == another[0] && s[1] == another[1]
+}
+
+// Compare returns -1 if receiver is smaller than another,
+// 1 if receiver is larger than another
+// and 0 if they are equal.
+func (s Semver) Compare(another Semver) int {
+	if res := compare(s[0], another[0]); res != 0 {
+		return res
+	}
+
+	if res := compare(s[1], another[1]); res != 0 {
+		return res
+	}
+
+	return compare(s[2], another[2])
+}
+
+func compare(a, b uint8) int {
+	if a > b {
+		return 1
+	}
+
+	if a < b {
+		return -1
+	}
+
+	return 0
+}

--- a/types/semver_test.go
+++ b/types/semver_test.go
@@ -1,0 +1,47 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/ffenix113/zigbee_home/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSemverCompare(t *testing.T) {
+	tests := []struct {
+		name       string
+		ver1, ver2 string
+		result     int
+	}{
+		{
+			name:   "equal",
+			ver1:   "v1.1.1",
+			ver2:   "v1.1.1",
+			result: 0,
+		},
+		{
+			name:   "less",
+			ver1:   "v1.6.200",
+			ver2:   "v1.7.0",
+			result: -1,
+		},
+		{
+			name:   "greater",
+			ver1:   "v1.0.0",
+			ver2:   "v0.3",
+			result: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ver1, err := types.ParseSemver(test.ver1)
+			require.NoError(t, err)
+
+			ver2, err := types.ParseSemver(test.ver2)
+			require.NoError(t, err)
+
+			require.Equal(t, test.result, ver1.Compare(ver2))
+		})
+	}
+}

--- a/types/source/source.go
+++ b/types/source/source.go
@@ -3,6 +3,7 @@ package source
 import (
 	"github.com/ffenix113/zigbee_home/config"
 	"github.com/ffenix113/zigbee_home/templates"
+	"github.com/ffenix113/zigbee_home/types"
 	"github.com/ffenix113/zigbee_home/types/generator"
 )
 
@@ -10,9 +11,9 @@ type Source struct {
 	templates *templates.Templates
 }
 
-func NewSource() *Source {
+func NewSource(ncsVersion types.Semver) *Source {
 	return &Source{
-		templates: templates.NewTemplates(templates.TemplateFS),
+		templates: templates.NewTemplates(templates.TemplateFS, ncsVersion),
 	}
 }
 


### PR DESCRIPTION
* [fix: map all ncs versions from toolchain config](https://github.com/ffenix113/zigbee_home/commit/30a987f179a5c974c434a68033d47ae1761b50ba)
* [chore: add simplest semver type](https://github.com/ffenix113/zigbee_home/commit/eed9a7e454be6306c82193ef4338971147905b24) - It is a simple implementation, that will be sufficient for its usecase
* [chore: add more examples](https://github.com/ffenix113/zigbee_home/commit/3b56c437ad9bf98ff4a5e3c2d009183c2c72c2d3)
* [chore: simplify cmd & config functions](https://github.com/ffenix113/zigbee_home/commit/f1752e4eb24f396aec5146f229f56dbc3be9957b) - This is the step forward to remove requirement of urfave/cli.
* [fix: version-aware template generation](https://github.com/ffenix113/zigbee_home/commit/165e3a7adc758bfd7d1306850f2549369977349e) - This would allow to generate different things for different toolchain versions.
For example on breaking changes with Zigbee custom implementations.
* [feat: generate firmware files for examples when testing](https://github.com/ffenix113/zigbee_home/commit/ae0db4372029e4f97082660c386c9e01d102a11f) - Doing this will be a good way to ensure that examples are staying
in sync with configuration & templates.