### PR TITLE
feat: experimental support for Trust center key

### DIFF
--- a/config/device.go
+++ b/config/device.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -44,6 +45,15 @@ type General struct {
 	// ZigbeeChannels will define which endpoints device should try to use.
 	// By default device will try all available channels.
 	ZigbeeChannels []int `yaml:"zigbee_channels"`
+	// TrustCenterKey is an optional configuration that will allow to
+	// set trust center key, which in turn would allow connecting to
+	// specific Zigbee hubs, like Philips Hue Bridge.
+	//
+	// This configuration option requires device to be set up
+	// as router or coordinator. End device does not support this option.
+	//
+	// Note: This option is EXPERIMENTAL
+	TrustCenterKey string `yaml:"trust_center_key"`
 	// Flasher defines the way the board should be flashed.
 	Flasher        string
 	FlasherOptions map[string]any
@@ -108,6 +118,10 @@ func ParseFromFile(configPath string) (*Device, error) {
 
 	if minimumNCSVersion.Compare(selectedNCSVersion) == 1 {
 		return nil, fmt.Errorf("selected NCS version is lower than minimum supported version: selected %q, minimum supported %q", cfg.General.NCSVersion, minimumNCSVersion)
+	}
+
+	if err := ValidateConfiguration(cfg); err != nil {
+		return nil, fmt.Errorf("validate configuration: %w", err)
 	}
 
 	return cfg, nil
@@ -224,15 +238,32 @@ func (g General) GetToochainsPath() NCSLocation {
 	}
 }
 
-func resolveStringEnv(input string) string {
-	if strings.HasPrefix(input, "~/") {
-		userHome, err := os.UserHomeDir()
-		if err != nil {
-			panic("could not resolve user home dir: " + err.Error())
+// ValidateConfiuration checks device configuration as much as it can
+// to provide meaningful information about errors in configuration.
+func ValidateConfiguration(cfg *Device) error {
+	if cfg.General.TrustCenterKey != "" {
+		log.Println("EXPERIMENTAL: Trust center key configuration is experimental and may not work as expected")
+
+		// Verify that key is of correct length.
+		// 32 chars + 15 colons
+		const keyLength = 32 + 15
+		if providedKeyLen := len(cfg.General.TrustCenterKey); providedKeyLen != keyLength {
+			return fmt.Errorf("trust center key has wrong length: want %d, have %d", keyLength, providedKeyLen)
 		}
 
-		input = strings.Replace(input, "~/", userHome+"/", 1)
+		if colonsCount := strings.Count(cfg.General.TrustCenterKey, ":"); colonsCount != 15 {
+			return fmt.Errorf("trust center key bytes shold be separated by colon: has %d colons, want 15", colonsCount)
+		}
+
+		// Trust center key is supported only for router & coordinator roles.
+		if !cfg.Board.IsRouter {
+			return errors.New("trust center key is provided, but board is not configured to be router")
+		}
 	}
 
+	return nil
+}
+
+func resolveStringEnv(input string) string {
 	return os.ExpandEnv(input)
 }

--- a/config/tag_resolver.go
+++ b/config/tag_resolver.go
@@ -85,8 +85,8 @@ func (r *tagsResolver) getIncludedNode(includePath string) (*yaml.Node, error) {
 }
 
 func (r *tagsResolver) getEnvNode(env string) (*yaml.Node, error) {
-	envValue, ok := os.LookupEnv(env)
-	if !ok || envValue == "" {
+	envValue := os.ExpandEnv(env)
+	if envValue == "" {
 		return nil, nil
 	}
 

--- a/examples/trust_center_key/README.md
+++ b/examples/trust_center_key/README.md
@@ -1,0 +1,11 @@
+## Set Trust center key
+
+### Advanced configuration, use only if it is required!
+
+For some hubs it may be necessary to set Trust center key and enable distributed mode, which
+differs from the default one defined in Zigbee specification.
+
+This can be necessary to connect to some hubs, for example Philips Hue Bridge.
+Please use Google to find how to get this key for your hub, if necessary.
+
+It is not necessary to provide this configuration option by default.

--- a/examples/trust_center_key/zigbee.yaml
+++ b/examples/trust_center_key/zigbee.yaml
@@ -1,0 +1,15 @@
+general:
+  runevery: 2m
+  board: xiao_ble
+  # If it is required to connect to specific hub (i.e. Philips Hue Bridge)
+  # it may be necessary to specify this value.
+  #
+  # Please use Google to find how to get this key for your hub, if necessary.
+  #
+  # Value in this example is the default key from Zigbee specification.
+  trust_center_key: 5A:69:67:42:65:65:41:6C:6C:69:61:6E:63:65:30:39
+
+board:
+  # is_router option is mandatory when setting Trust center key.
+  # If it is not set - an error will be returned telling to set it.
+  is_router: true

--- a/templates/src/main.cpp.tpl
+++ b/templates/src/main.cpp.tpl
@@ -251,6 +251,16 @@ static void loop(zb_bufid_t bufid)
 	}
 }
 
+void setup_trust_center_key() {
+	{{/* A quick hack to setup trust key if it was provided */}}
+	{{ if not (eq .Device.General.TrustCenterKey "")}}
+	zb_enable_distributed();
+	
+	uint8_t secret_zll_trust_center_key[16] = { {{ trustCenterKeyToArray .Device.General.TrustCenterKey }} };
+	zb_zdo_set_tc_standard_distributed_key(secret_zll_trust_center_key);
+	{{ end }}
+}
+
 int init_templates() {
 	// --- Extenders start
 	{{- range .Extenders}}
@@ -455,6 +465,10 @@ int main(void)
 
 	/* Register callback to identify notifications */
 	// ZB_AF_SET_IDENTIFY_NOTIFICATION_HANDLER(DEVICE_ENDPOINT_NB, identify_callback);
+
+	// While the call to set up trust center key is always present
+	// its implemenentation will depend if it was provided or not.
+	setup_trust_center_key();
 
 	#if CONFIG_ZIGBEE_ROLE_END_DEVICE
 	/* Enable Sleepy End Device behavior */

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -127,17 +128,18 @@ func NewTemplates(templateFS fs.FS, ncsVersion types.Semver) *Templates {
 	}
 
 	t.templates.Funcs(template.FuncMap{
-		"typeFromSensor":      typeFromSensor,
-		"clusterTpl":          t.clusterTpl,
-		"render":              t.render,
-		"maybeRender":         t.maybeRender,
-		"maybeRenderExtender": t.maybeRenderExtender,
-		"toButtonBit":         toButtonBit,
-		"sensorCtx":           sensorCtx,
-		"clusterCtx":          clusterCtx,
-		"isLast":              isLast,
-		"sum":                 sum,
-		"formatHex":           formatHex,
+		"typeFromSensor":        typeFromSensor,
+		"clusterTpl":            t.clusterTpl,
+		"render":                t.render,
+		"maybeRender":           t.maybeRender,
+		"maybeRenderExtender":   t.maybeRenderExtender,
+		"toButtonBit":           toButtonBit,
+		"sensorCtx":             sensorCtx,
+		"clusterCtx":            clusterCtx,
+		"isLast":                isLast,
+		"sum":                   sum,
+		"formatHex":             formatHex,
+		"trustCenterKeyToArray": trustCenterKeyToArray,
 		"joinPath": func(strs ...string) string {
 			return path.Join(strs...)
 		},
@@ -518,6 +520,30 @@ func formatHex(val any) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown type to format: %T", val)
 	}
+}
+
+// trustCenterKeyToArray will return trust key as C array item values.
+func trustCenterKeyToArray(key string) (string, error) {
+	key = strings.ReplaceAll(key, ":", "")
+
+	var sb strings.Builder
+
+	for i := 0; i < 16; i++ {
+		bytePart := key[i*2 : i*2+2]
+
+		_, err := strconv.ParseUint(bytePart, 16, 16)
+		if err != nil {
+			return "", fmt.Errorf("parse trust center key part %q: %w", bytePart, err)
+		}
+
+		if i != 0 {
+			sb.WriteString(", ")
+		}
+
+		sb.WriteString("0x" + bytePart)
+	}
+
+	return sb.String(), nil
 }
 
 func ncsVersionIs(current, another types.Semver) func() bool {


### PR DESCRIPTION
This configuration would allow setting Trust center key and distributed mode, which can be required for some hubs,
for example Philips Hue Bridge.

It does not mean that it will work perfectly,
or that all device features will be supported by the hub.

Ref: https://wejn.org/2025/01/zigbee-hue-llo-world/

As discussed in https://github.com/ffenix113/zigbee_home/discussions/86