### PR TITLE
chore: add builds for each commit on develop

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,11 +14,41 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-        cache-dependency-path: go.sum
-    - name: Test
-      run: go test ./...
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: go.sum
+      - name: Test
+        run: go test ./...
+
+  build:
+    runs-on: ubuntu-latest
+    # Do not do builds on pull requests.
+    # Maybe this will be lifted in the future,
+    # if MR builds would be useful for users
+    # before they are merged.
+    if: ${{ github.event_name == 'push' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: go.sum
+      - name: Install dependencies
+        run: go mod download
+      - name: Build executables
+        # Yes, build matrix can be used, but I don't want to create multiple jobs
+        # for something that can be done in one step.
+        run: |
+          export GOOS=windows; export GOARCH=amd64; go build -o builds/zigbee_home_${GOOS}_${GOARCH}.exe ./cmd/zigbee/
+          export GOOS=linux; export GOARCH=amd64; go build -o builds/zigbee_home_${GOOS}_${GOARCH} ./cmd/zigbee/
+          export GOOS=darwin; export GOARCH=arm64; go build -o builds/zigbee_home_${GOOS}_${GOARCH} ./cmd/zigbee/
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zigbee_home_executables
+          if-no-files-found: error
+          path: builds/*

--- a/cmd/zigbee/main.go
+++ b/cmd/zigbee/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"runtime/debug"
-	"slices"
 
 	"github.com/ffenix113/zigbee_home/cmd/zigbee/firmware"
 	"github.com/urfave/cli/v2"
@@ -54,29 +53,9 @@ func printVersion() error {
 		return errors.New("could not read build information")
 	}
 
-	vcsProps := make([]debug.BuildSetting, 0, 2)
-
-	for _, setting := range buildInfo.Settings {
-		if !slices.Contains([]string{"vcs.revision", "vcs.modified"}, setting.Key) {
-			continue
-		}
-
-		vcsProps = append(vcsProps, setting)
-		if len(vcsProps) == cap(vcsProps) {
-			break
-		}
-	}
-
-	slices.SortFunc(vcsProps, func(a, b debug.BuildSetting) int {
-		if a.Key > b.Key {
-			return 1
-		}
-
-		return -1
-	})
-
-	// Information that will help with investigation of
-	log.Printf("%s, tag:%s, version:%s", buildInfo.GoVersion, buildInfo.Main.Version, vcsProps)
+	// Information that will help with investigation of issues,
+	// or just an information to know if update is needed or not.
+	log.Printf("%s, version:%s", buildInfo.GoVersion, buildInfo.Main.Version)
 
 	return nil
 }

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"text/template"
@@ -250,9 +251,16 @@ func templateFromPath(root *templateTree, baseTpl *template.Template, tplPath st
 }
 
 func (t *Templates) WriteTo(srcDir string, device *config.Device, extenders []generator.Extender) error {
+	appVersion := "no-version"
+
+	dbgInfo, ok := debug.ReadBuildInfo()
+	if ok {
+		appVersion = dbgInfo.Main.Version
+	}
+
 	ctx := Context{
 		GeneratedOn: time.Now().UTC(),
-		Version:     "0.0.0-dev",
+		Version:     appVersion,
 		Device:      device,
 
 		Extenders: extenders,


### PR DESCRIPTION
This would allow users to download executable,
without need to compile it themselves.

Next step to add artifacts to releases.