### PR TITLE
chore: add more gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,14 @@
 /vendor
 /test
 
+# Dot files are not necessary, unless forced
+# Especially on MacOS..
+.*
+
 # Test builds
 /_*
+
+# Test configurations
+zigbee_*.yaml
+# Test build environment (for now)
+compose.yml


### PR DESCRIPTION
Some test- and OS-related files are a chore to skip/stash while creating a commit.