### PR TITLE
feat: setup watchdog

### DIFF
--- a/config/device.go
+++ b/config/device.go
@@ -60,8 +60,17 @@ type General struct {
 }
 
 type Board struct {
-	Bootloader         *string
-	Debug              *extenders.DebugConfig
+	Bootloader *string
+	Debug      *extenders.DebugConfig
+	// EnableWatchdog will setup watchdog timer that
+	// will reset SoC if it was not "fed" (i.e. pinged)
+	// in some time.
+	//
+	// This option is set to true by default,
+	// and can only be disabled.
+	//
+	// It is always disabled if configuration is set in debug mode.
+	EnableWatchdog     bool   `yaml:"enable_watchdog"`
 	IsRouter           bool   `yaml:"is_router"`
 	FactoryResetButton string `yaml:"factory_reset_button"`
 	NetworkStateLED    string `yaml:"network_state_led"`
@@ -89,6 +98,9 @@ func ParseFromFile(configPath string) (*Device, error) {
 			NCSVersion:   minimumNCSVersion.String(),
 			Manufacturer: "FFexix113",
 			DeviceName:   "dongle",
+		},
+		Board: Board{
+			EnableWatchdog: true,
 		},
 	}
 

--- a/examples/disable_watchdog/README.md
+++ b/examples/disable_watchdog/README.md
@@ -1,0 +1,12 @@
+## Disable watchdog
+
+This example shows how to disable watchdog.
+
+Generally users should not need to do this, but if some specific requirements need to disable it - it can be done.
+For example in case of minimal possible power consumption.
+
+Watchdog is always disabled when debug configuration is enabled.
+
+### Notes
+* Watchdog power consumption may be negligable compared to selected sensors and other options.
+* If device locks-up or otherwise misbehaves and watchdog is disabled it would require manual reset / power cycle of the board.

--- a/examples/disable_watchdog/zigbee.yaml
+++ b/examples/disable_watchdog/zigbee.yaml
@@ -1,0 +1,5 @@
+general:
+  board: nrf52840dongle_nrf52840
+
+board:
+  enable_watchdog: false

--- a/generate/generator.go
+++ b/generate/generator.go
@@ -26,6 +26,7 @@ type Generator struct {
 func NewGenerator(device *config.Device) (*Generator, error) {
 	appConfig, err := appconfig.NewDefaultAppConfig(
 		appconfig.DefaultAppConfigOptions{
+			EnableWatchdog: device.Board.EnableWatchdog,
 			IsRouter:       device.Board.IsRouter,
 			ZigbeeChannels: device.General.ZigbeeChannels,
 		},

--- a/templates/src/Kconfig.tpl
+++ b/templates/src/Kconfig.tpl
@@ -1,3 +1,10 @@
+config ZBHOME_WATCHDOG_ENABLE
+	bool "Enable watchdog"
+	default y
+	imply WATCHDOG
+	help
+	  Enable watchdog that will reset SoC (and so the board) in case of a lock up.
+
 config ZBHOME_DEBUG_ENABLE
 	bool "Debug configuration"
 	default n

--- a/templates/src/main.cpp.tpl
+++ b/templates/src/main.cpp.tpl
@@ -400,6 +400,20 @@ void zboss_signal_handler(zb_bufid_t bufid)
 	/* Detect ZBOSS startup */
 	switch (signal) {
 	case ZB_ZDO_SIGNAL_SKIP_STARTUP:
+	// Enable watchdog only on "production" configuration.
+	// On debugging it will be just annoying to constantly reset SoC
+	// while trying to read logs or debug.
+#if !CONFIG_ZBHOME_DEBUG_ENABLE
+		if (int err = setup_watchdog(); err != 0)
+		{
+			LOG_ERR("setup watchdog err: %d", err);
+		}
+		else
+		{
+			LOG_INF("watchdog was set");
+		}
+#endif
+
 		if (!init_zbhome())
 		{
 			LOG_ERR("cannot initiate zbhome");

--- a/templates/src/main.cpp.tpl
+++ b/templates/src/main.cpp.tpl
@@ -29,6 +29,8 @@ extern "C" {
 #include <zigbee/zigbee_app_utils.h>
 #include <zigbee/zigbee_error_handler.h>
 
+#include "watchdog.hpp"
+
 // Header only, why not?
 #include "device.hpp"
 
@@ -403,7 +405,7 @@ void zboss_signal_handler(zb_bufid_t bufid)
 	// Enable watchdog only on "production" configuration.
 	// On debugging it will be just annoying to constantly reset SoC
 	// while trying to read logs or debug.
-#if !CONFIG_ZBHOME_DEBUG_ENABLE
+#if CONFIG_ZBHOME_WATCHDOG_ENABLE && !CONFIG_ZBHOME_DEBUG_ENABLE
 		if (int err = setup_watchdog(); err != 0)
 		{
 			LOG_ERR("setup watchdog err: %d", err);

--- a/templates/src/watchdog.hpp
+++ b/templates/src/watchdog.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+/*
+ * Copyright (c) 2015 Intel Corporation
+ * Copyright (c) 2018 Nordic Semiconductor
+ * Copyright (c) 2019 Centaur Analytics, Inc
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This header will allow enabling watchdog,
+// which in turn would reset SoC in case
+// of some lock up.
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/watchdog.h>
+
+#define WDT_MAX_WINDOW 65000U
+#define WDG_FEED_INTERVAL 60000U
+
+// This check is present as we don't
+// force watchdog on in the devicetree.
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_wdt)
+const struct device *const wdt = DEVICE_DT_GET(DT_ALIAS(watchdog0));
+#else
+const struct device *const wdt = NULL;
+#endif
+
+static struct wdt_window wdt_window_cfg = {
+    .min = WDT_MIN_WINDOW,
+    .max = WDT_MAX_WINDOW,
+};
+
+static struct wdt_timeout_cfg wdt_config = {
+    /* Expire watchdog after max window */
+    .window = wdt_window_cfg,
+    /* Reset SoC when watchdog timer expires. */
+    .flags = WDT_FLAG_RESET_SOC,
+};
+
+static int wdt_channel_id;
+
+void feed_watchdog(struct k_timer *dummy)
+{
+    wdt_feed(wdt, wdt_channel_id);
+};
+
+K_TIMER_DEFINE(wdt_timer, feed_watchdog, NULL);
+
+int setup_watchdog()
+{
+    // If we don't have watchdog - don't sweat it, for now.
+    if (!wdt)
+    {
+        return -1;
+    }
+
+    int err;
+    if (!device_is_ready(wdt))
+    {
+        return -2;
+    }
+
+    wdt_channel_id = wdt_install_timeout(wdt, &wdt_config);
+    if (wdt_channel_id < 0)
+    {
+        return -3;
+    }
+
+    err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
+    if (err < 0)
+    {
+        return -4;
+    }
+
+    // Schedule feeding of watchdog
+    k_timer_start(&wdt_timer, K_SECONDS(WDG_FEED_INTERVAL / 1000), K_SECONDS(WDG_FEED_INTERVAL / 1000));
+
+    return 0;
+};

--- a/templates/src/watchdog.hpp
+++ b/templates/src/watchdog.hpp
@@ -22,14 +22,14 @@
 
 // This check is present as we don't
 // force watchdog on in the devicetree.
-#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_wdt)
+#if CONFIG_ZBHOME_WATCHDOG_ENABLE && !CONFIG_ZBHOME_DEBUG_ENABLE && DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_wdt)
 const struct device *const wdt = DEVICE_DT_GET(DT_ALIAS(watchdog0));
 #else
 const struct device *const wdt = NULL;
 #endif
 
 static struct wdt_window wdt_window_cfg = {
-    .min = WDT_MIN_WINDOW,
+    .min = 0,
     .max = WDT_MAX_WINDOW,
 };
 

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -68,6 +68,7 @@ var sourceFiles = [][2]string{
 	{path.Join("..", "sysbuild", "802154_rpmsg.overlay"), "sysbuild/802154_rpmsg.overlay"},
 	{path.Join("..", "sysbuild", "mcuboot.conf"), "sysbuild/mcuboot.conf"},
 	{"main.cpp", "main.cpp.tpl"},
+	{"watchdog.hpp", "watchdog.hpp"},
 	{"device.hpp", "device.hpp.tpl"},
 	{"clusters.hpp", "clusters.hpp.tpl"},
 	{"types.hpp", "types.hpp"},

--- a/types/appconfig/appconfig.go
+++ b/types/appconfig/appconfig.go
@@ -38,6 +38,15 @@ func (v ConfigValue) Required(val string) ConfigValue {
 	return v
 }
 
+func (v ConfigValue) RequiredBool(val bool) ConfigValue {
+	v.RequiredValue = Yes
+	if !val {
+		v.RequiredValue = No
+	}
+
+	return v
+}
+
 func (v ConfigValue) Quoted() ConfigValue {
 	v.QuotedValue = true
 	return v
@@ -86,6 +95,7 @@ func NewEmptyAppConfig() *AppConfig {
 }
 
 type DefaultAppConfigOptions struct {
+	EnableWatchdog bool
 	IsRouter       bool
 	ZigbeeChannels []int
 }
@@ -114,6 +124,8 @@ func NewDefaultAppConfig(opts DefaultAppConfigOptions) (*AppConfig, error) {
 		CONFIG_NET_UDP,
 		CONFIG_CONSOLE,
 		CONFIG_USB_DEVICE_STACK,
+
+		CONFIG_ZBHOME_WATCHDOG_ENABLE.RequiredBool(opts.EnableWatchdog),
 	)
 
 	deviceRole := CONFIG_ZIGBEE_ROLE_END_DEVICE

--- a/types/appconfig/known.go
+++ b/types/appconfig/known.go
@@ -5,6 +5,9 @@ package appconfig
 // As such they do not represent good/best configurations,
 // but mostly the ones that work for this project.
 var (
+	// ZBHome config
+	CONFIG_ZBHOME_WATCHDOG_ENABLE = NewValue("CONFIG_ZBHOME_WATCHDOG_ENABLE").Default(Yes)
+
 	// Zephyr config
 	CONFIG_CPP                  = NewValue("CONFIG_CPP").Default(Yes)
 	CONFIG_REQUIRES_FULL_LIBCPP = NewValue("CONFIG_REQUIRES_FULL_LIBCPP").Default(Yes)

--- a/zigbee.yaml
+++ b/zigbee.yaml
@@ -65,6 +65,15 @@ board:
   # to be selected one, even if the value is empty string.
   #bootloader: nrf52_legacy
 
+  # This option enables watchdog, that will reset the board
+  # in case of lock-up or similar misbehavior.
+  #
+  # It is enabled by default and is present here to only showcase the option.
+  #
+  # User can disable watchdog by setting this options to "false".
+  # It is also always disabled when debug.enabled == true.
+  enable_watchdog: true
+
   # This will make "button0" factory reset button. 
   # Pressing this button for at least 5 seconds 
   # would remove current network configuration,


### PR DESCRIPTION
It can be a temporary solution to situations where unknown issue will lock up SoC resulting
in values not being updated and not responding to commands.

"Production" configuration will already automatically reset SoC on assert fail, but issue may not always be a failing assert,
but a memory related issue, for example/