### PR TITLE
chore: use more 'filepath' package instead of 'path'

### DIFF
--- a/config/device_test.go
+++ b/config/device_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,7 +38,7 @@ func TestLoadExamples(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 
-	examplesPath := path.Join(cwd, "..", "examples")
+	examplesPath := filepath.Join(cwd, "..", "examples")
 	examples, err := os.ReadDir(examplesPath)
 	if err != nil {
 		t.Skipf("cannot read examples dir: %s", err.Error())
@@ -54,12 +54,12 @@ func TestLoadExamples(t *testing.T) {
 		}
 
 		t.Run(example.Name(), func(t *testing.T) {
-			examplePath := path.Join(examplesPath, example.Name())
+			examplePath := filepath.Join(examplesPath, example.Name())
 			// We need to change directory as some files can contain includes,
 			// which will be relative to the configuration file.
 			require.NoError(t, os.Chdir(examplePath))
 
-			defaultConfig, err := os.Open(path.Join(examplePath, "zigbee.yaml"))
+			defaultConfig, err := os.Open(filepath.Join(examplePath, "zigbee.yaml"))
 			if errors.Is(err, os.ErrNotExist) {
 				t.Skip("default config not found")
 			}

--- a/config/ncs_finder.go
+++ b/config/ncs_finder.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -183,8 +182,8 @@ func listSDKs(ncsBase string) ([]SDKInfo, error) {
 			continue
 		}
 
-		versionFilePath := path.Join(ncsBase, entry.Name(), "nrf", "VERSION")
-		zigbeeAddOnPath := path.Join(ncsBase, entry.Name(), "ncs-zigbee")
+		versionFilePath := filepath.Join(ncsBase, entry.Name(), "nrf", "VERSION")
+		zigbeeAddOnPath := filepath.Join(ncsBase, entry.Name(), "ncs-zigbee")
 
 		bts, err := os.ReadFile(versionFilePath)
 		if err != nil {
@@ -204,7 +203,7 @@ func listSDKs(ncsBase string) ([]SDKInfo, error) {
 		isZigbeeAddOn := err == nil
 
 		sdks = append(sdks, SDKInfo{
-			Path:          path.Join(ncsBase, entry.Name()),
+			Path:          filepath.Join(ncsBase, entry.Name()),
 			Version:       sdkVersion,
 			IsZigbeeAddOn: isZigbeeAddOn,
 		})

--- a/runner/cmd.go
+++ b/runner/cmd.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 )
@@ -149,6 +148,7 @@ func extendEnv(ncsToolchainPath string, sdkPath string) []string {
 		combinedPath += string(os.PathListSeparator) + envPath
 	}
 
+	// This is Linux specific, so may not work correctly on Windows.
 	ldLibraryPath := generateEnvArray(ncsToolchainPath, []string{
 		"/usr/lib",
 		"/usr/lib/x86_64-linux-gnu",
@@ -158,7 +158,7 @@ func extendEnv(ncsToolchainPath string, sdkPath string) []string {
 	return []string{
 		"PATH=" + combinedPath,
 		"ZEPHYR_BASE=" + sdkPath,
-		"ZEPHYR_SDK_INSTALL_DIR=" + path.Join(ncsToolchainPath, "/opt/zephyr-sdk"),
+		"ZEPHYR_SDK_INSTALL_DIR=" + filepath.Join(ncsToolchainPath, "opt", "zephyr-sdk"),
 		"ZEPHYR_TOOLCHAIN_VARIANT=zephyr",
 		"LD_LIBRARY_PATH=" + ldLibraryPath,
 	}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -62,11 +62,11 @@ var knownClusterTemplates = map[cluster.ID]string{
 }
 
 var sourceFiles = [][2]string{
-	{path.Join("..", "CMakeLists.txt"), "CMakeLists.txt.tpl"},
-	{path.Join("..", "Kconfig"), "Kconfig.tpl"},
-	{path.Join("..", "Kconfig.sysbuild"), "Kconfig.sysbuild.tpl"},
-	{path.Join("..", "sysbuild", "802154_rpmsg.overlay"), "sysbuild/802154_rpmsg.overlay"},
-	{path.Join("..", "sysbuild", "mcuboot.conf"), "sysbuild/mcuboot.conf"},
+	{filepath.Join("..", "CMakeLists.txt"), "CMakeLists.txt.tpl"},
+	{filepath.Join("..", "Kconfig"), "Kconfig.tpl"},
+	{filepath.Join("..", "Kconfig.sysbuild"), "Kconfig.sysbuild.tpl"},
+	{filepath.Join("..", "sysbuild", "802154_rpmsg.overlay"), "sysbuild/802154_rpmsg.overlay"},
+	{filepath.Join("..", "sysbuild", "mcuboot.conf"), "sysbuild/mcuboot.conf"},
 	{"main.cpp", "main.cpp.tpl"},
 	{"watchdog.hpp", "watchdog.hpp"},
 	{"device.hpp", "device.hpp.tpl"},
@@ -142,9 +142,6 @@ func NewTemplates(templateFS fs.FS, ncsVersion types.Semver) *Templates {
 		"sum":                   sum,
 		"formatHex":             formatHex,
 		"trustCenterKeyToArray": trustCenterKeyToArray,
-		"joinPath": func(strs ...string) string {
-			return path.Join(strs...)
-		},
 		// Specific functions to check exact version
 		// so we would know where each one is used,
 		// and what we can deprecate.
@@ -281,7 +278,7 @@ func (t *Templates) WriteTo(srcDir string, device *config.Device, extenders []ge
 			return fmt.Errorf("tried to write unknown template: %q", sourceDefinition[1])
 		}
 
-		if err := writeTemplate(template, path.Join(srcDir, sourceDefinition[0]), ctx); err != nil {
+		if err := writeTemplate(template, filepath.Join(srcDir, sourceDefinition[0]), ctx); err != nil {
 			return fmt.Errorf("write template: %w", err)
 		}
 	}


### PR DESCRIPTION
'filepath' package uses OS path separator, while 'path' uses URL ('/') path separator.

Embedded FS always needs slash, so use 'path' there.