### PR TITLE
fix: do not do setup work if requested not to

### DIFF
--- a/config/device.go
+++ b/config/device.go
@@ -225,6 +225,11 @@ func (d *Device) PrependCommonClusters() {
 }
 
 func (g General) GetToochainsPath() NCSLocation {
+	// If we already have env set - don't do anything.
+	if DoNotSetupEnv() {
+		return NCSLocation{}
+	}
+
 	// If env variables are defined - they have higher priority.
 	ncsToolchainPath := os.Getenv("NCS_TOOLCHAIN_BASE")
 	ncsSDKVersion := os.Getenv("NCS_VERSION")
@@ -289,6 +294,8 @@ func ValidateConfiguration(cfg *Device) error {
 	return nil
 }
 
-func resolveStringEnv(input string) string {
-	return os.ExpandEnv(input)
+func DoNotSetupEnv() bool {
+	_, ok := os.LookupEnv("NO_SETUP_ENV")
+
+	return ok
 }

--- a/runner/cmd.go
+++ b/runner/cmd.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/ffenix113/zigbee_home/config"
 )
 
 type Cmd struct {
@@ -82,7 +84,7 @@ func WithToolchainPath(ncsToolchainBase, sdkBase string) CmdOpt {
 	// and move it to CLI ASAP.
 	// This could be useful if run inside environment that
 	// is already set up properly.
-	if noSetupEnv() || ncsToolchainBase == "" || sdkBase == "" {
+	if config.DoNotSetupEnv() || ncsToolchainBase == "" || sdkBase == "" {
 		log.Println("environment will not be prepared because either one of the paths is empty, or requested not to")
 
 		return func(c *exec.Cmd) {}
@@ -191,10 +193,4 @@ func updateCurrentPath(envs []string) {
 	if envPath != "" {
 		os.Setenv("PATH", envPath)
 	}
-}
-
-func noSetupEnv() bool {
-	_, ok := os.LookupEnv("NO_SETUP_ENV")
-
-	return ok
 }


### PR DESCRIPTION
This excludes unnecessary (and sometimes maybe hurtful) work to prepare environment, but not use it.