### PR TITLE
chore: small fixes

### DIFF
--- a/config/device.go
+++ b/config/device.go
@@ -119,7 +119,7 @@ func ParseFromFile(configPath string) (*Device, error) {
 					case "darwin":
 						return "/opt/nordic/ncs"
 					default:
-						return "~/ncs"
+						return os.ExpandEnv("$HOME/ncs")
 					}
 				}(),
 			},

--- a/types/appconfig/appconfig.go
+++ b/types/appconfig/appconfig.go
@@ -106,6 +106,7 @@ type DefaultSysbuildConfigOptions struct {
 
 func NewDefaultAppConfig(opts DefaultAppConfigOptions) (*AppConfig, error) {
 	appConfig := NewEmptyAppConfig().AddValue(
+		CONFIG_CONSOLE,
 		CONFIG_CPP,
 		CONFIG_REQUIRES_FULL_LIBCPP,
 		CONFIG_STD_CPP17,

--- a/types/appconfig/known.go
+++ b/types/appconfig/known.go
@@ -14,6 +14,7 @@ var (
 	CONFIG_STD_CPP17            = NewValue("CONFIG_STD_CPP17").Default(Yes)
 
 	// Logging
+	CONFIG_CONSOLE          = NewValue("CONFIG_CONSOLE").Default(No)
 	CONFIG_UART_CONSOLE     = NewValue("CONFIG_UART_CONSOLE").Default(No)
 	CONFIG_UART_LINE_CTRL   = NewValue("CONFIG_UART_LINE_CTRL").Default(Yes)
 	CONFIG_LOG_BACKEND_UART = NewValue("CONFIG_LOG_BACKEND_UART").Default(Yes)


### PR DESCRIPTION
* Update default sdk base path for Linux to replace `~` with resolved `HOME` variable.
* Fix `CONSOLE` config option not being disabled by default. It will be selected as necessary if debug is enabled.