### PR TITLE
feat: working ci builds

### DIFF
--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -36,6 +36,6 @@ jobs:
         run: |
           ./nrfutil sdk-manager list --all-fields
           ./nrfutil sdk-manager list --json
-          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0])
+          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0])"
           echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
           ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c 'printenv && ./zigbee_home --config zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -40,7 +40,7 @@ jobs:
             ~/ncs/${{ env.SDK_VERSION }}
           key: ${{ runner.os }}-ncs-${{ env.SDK_VERSION }}
       - name: Download Toolchain and SDK
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
+        if: steps.cache-sdk-restore.outputs.cache-hit != 'true'
         run: ./nrfutil sdk-manager install ${SDK_VERSION}
       - name: Verify toolchain and sdk are installed
         run: |

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -58,6 +58,8 @@ jobs:
           ./nrfutil toolchain-manager install --ncs-version ${TOOLCHAIN_VERSION}
           mkdir ~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION}
           
+          ln -s /lib/x86_64-linux-gnu/libunistring.so.{5.0.0,2}
+
           ./nrfutil toolchain-manager launch --chdir ~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION} --ncs-version ${TOOLCHAIN_VERSION} -- \
           bash -c 'west init -m "http://github.com/nrfconnect/ncs-zigbee" --mr ${ZIGBEE_ADD_ON_VERSION} && \
           west update -o=--depth=1 -n'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -10,7 +10,10 @@ concurrency:
 jobs:
   empty:
     runs-on: ubuntu-latest
-    container: ghcr.io/zephyrproject-rtos/ci:v0.28.6
+    env:
+      SDK_VERSION: v2.9.2
+      # Let zigbee_home know that env is already set up.
+      NO_SETUP_ENV: 1
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -18,11 +21,18 @@ jobs:
         with:
           go-version: '1.24'
           cache-dependency-path: go.sum
-      - name: Pull Nordic Zigbee Add on SDK
-        run: | 
-          west init -m "http://github.com/nrfconnect/ncs-zigbee" --mr v1.2.1
-          west update
       - name: Build executable
         run: go build -o zigbee_home ./cmd/zigbee/; chmod +x ./zigbee_home
+      - name: Download nrfutil
+        run: | 
+          wget https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
+          chmod +x nrfutil
+      - name: Pull Toolchain and SDK
+        run: |
+          ./nrfutil install toolchain-manager
+          ./nrfutil install sdk-manager
+          ./nrfutil sdk-manager install ${SDK_VERSION}
       - name: Build project
-        run: ./zigbee_home --config zigbee.yaml firmware --workdir project build
+        run: |
+          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq '.data.versions[] | select(.version == "${SDK_VERSION}").dirNames[0]')
+          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} ./zigbee_home --config zigbee.yaml firmware --workdir project build

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -1,4 +1,4 @@
-name: Prepared SDK env
+name: Build CI firmware
 
 on:
   workflow_dispatch:
@@ -8,56 +8,69 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  empty:
+  build_firmware:
     runs-on: ubuntu-latest
     env:
       SDK_VERSION: v2.9.2
-      # Let zigbee_home know that env is already set up.
-      NO_SETUP_ENV: 1
+      GO_VERSION: '1.24'
+      NRFUTIL_VERSION: '8.1.1'
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: go.sum
       - name: Build executable
         run: go build -o zigbee_home ./cmd/zigbee/; chmod +x ./zigbee_home
-      - name: Download nrfutil
-        run: | 
-          wget --progress=dot:mega https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
-          chmod +x nrfutil
-      - name: Install Toolchain and SDK managers
-        run: |
-          ./nrfutil install toolchain-manager sdk-manager
 
       - name: Restore cached SDK
-        id: cache-sdk-restore
+        id: cache-sdk
         uses: actions/cache/restore@v4
         with:
           path: |
+            ${{ github.workspace }}/nrfutil
+            ~/.nrfutil/bin
             ~/ncs/toolchains
             ~/ncs/${{ env.SDK_VERSION }}
-          key: ${{ runner.os }}-ncs-${{ env.SDK_VERSION }}
+          key: ${{ runner.os }}-ncs-${{ env.SDK_VERSION }}-nrfutil-${{ env.NRFUTIL_VERSION }}
+      - name: Download nrfutil
+        if: steps.cache-sdk.outputs.cache-hit != 'true'
+        env:
+          BASE_URL: https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/packages/nrfutil
+        run: | 
+          wget --progress=dot:mega -O nrfutil.tar.gz ${BASE_URL}/nrfutil-x86_64-unknown-linux-gnu-${NRFUTIL_VERSION}.tar.gz
+          tar -xOf ./nrfutil.tar.gz ./nrfutil-x86_64-unknown-linux-gnu-${NRFUTIL_VERSION}/data/bin/nrfutil > nrfutil
+          rm ./nrfutil.tar.gz
+          chmod +x nrfutil
+      - name: Install Toolchain and SDK managers
+        if: steps.cache-sdk.outputs.cache-hit != 'true'
+        run: |
+          ./nrfutil install toolchain-manager sdk-manager
+          ./nrfutil list
       - name: Download Toolchain and SDK
-        if: steps.cache-sdk-restore.outputs.cache-hit != 'true'
+        if: steps.cache-sdk.outputs.cache-hit != 'true'
         run: ./nrfutil sdk-manager install ${SDK_VERSION}
       - name: Verify toolchain and sdk are installed
         run: |
+          ./nrfutil -V
           ./nrfutil toolchain-manager list
           ./nrfutil sdk-manager list --all-fields
       - name: Cache downloaded SDK
-        if: steps.cache-sdk-restore.outputs.cache-hit != 'true'
+        if: steps.cache-sdk.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
+            ${{ github.workspace }}/nrfutil
+            ~/.nrfutil/bin
             ~/ncs/toolchains
             ~/ncs/${{ env.SDK_VERSION }}
-          key: ${{ steps.cache-sdk-restore.outputs.cache-primary-key }}
+          key: ${{ steps.cache-sdk.outputs.cache-primary-key }}
 
       - name: Build project
+        env:
+          # Let zigbee_home know that env is already set up.
+          NO_SETUP_ENV: 1
         run: |
-          ./nrfutil sdk-manager list --all-fields
           export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq -r ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0] + \"/zephyr\"")
-          echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
+          echo "Set ZEPHYR_BASE at ${ZEPHYR_BASE}."
           ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c './zigbee_home --config ./examples/basic/zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -1,4 +1,4 @@
-name: Build CI firmware
+name: Build firmware
 
 on:
   workflow_dispatch:
@@ -14,6 +14,10 @@ jobs:
       # Somehow we should try to keep Add On and Toolchain in sync.
       # But as we download toolchain before Add On - we can't fetch 
       # version from downloaded Add On.
+      #
+      # Technically we could resolve latest tag, then fetch the west.yml, 
+      # parse it and return 'manifest.projects[0].revision'. Though sounds like a handful.
+      #
       # Though I can confirm that having SDK verion of 2.9.2 works with Toolchain v3.1.0
       ZIGBEE_ADD_ON_VERSION: v1.2.1
       TOOLCHAIN_VERSION: v3.1.1
@@ -29,6 +33,7 @@ jobs:
         run: go build -o zigbee_home ./cmd/zigbee/; chmod +x ./zigbee_home
 
       - name: Restore cached SDK
+        if: ${{ !env.ACT }}
         id: cache-sdk
         uses: actions/cache/restore@v4
         with:
@@ -62,7 +67,7 @@ jobs:
           bash -c 'west init -m "http://github.com/nrfconnect/ncs-zigbee" --mr ${ZIGBEE_ADD_ON_VERSION} && \
           west update -o=--depth=1 -n'
       - name: Cache downloaded SDK
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
+        if: ${{ !env.ACT && steps.cache-sdk.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -25,14 +25,15 @@ jobs:
         run: go build -o zigbee_home ./cmd/zigbee/; chmod +x ./zigbee_home
       - name: Download nrfutil
         run: | 
-          wget https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
+          wget --progress=dot:binary https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
           chmod +x nrfutil
-      - name: Pull Toolchain and SDK
+      - name: Install Toolchain and SDK managers
         run: |
           ./nrfutil install toolchain-manager
           ./nrfutil install sdk-manager
-          ./nrfutil sdk-manager install ${SDK_VERSION}
+      - name: Download Toolchain and SDK
+        run: ./nrfutil sdk-manager install ${SDK_VERSION}
       - name: Build project
         run: |
           export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq '.data.versions[] | select(.version == "${SDK_VERSION}").dirNames[0]')
-          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} ./zigbee_home --config zigbee.yaml firmware --workdir project build
+          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- ./zigbee_home --config zigbee.yaml firmware --workdir project build

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -36,6 +36,6 @@ jobs:
         run: |
           ./nrfutil sdk-manager list --all-fields
           ./nrfutil sdk-manager list --json
-          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0])"
+          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0]")
           echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
           ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c 'printenv && ./zigbee_home --config zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -15,14 +15,14 @@ jobs:
       # Let zigbee_home know that env is already set up.
       NO_SETUP_ENV: 1
     steps:
-      # - uses: actions/checkout@v4
-      # - name: Set up Go
-      #   uses: actions/setup-go@v5
-      #   with:
-      #     go-version: '1.24'
-      #     cache-dependency-path: go.sum
-      # - name: Build executable
-      #   run: go build -o zigbee_home ./cmd/zigbee/; chmod +x ./zigbee_home
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: go.sum
+      - name: Build executable
+        run: go build -o zigbee_home ./cmd/zigbee/; chmod +x ./zigbee_home
       - name: Download nrfutil
         run: | 
           wget --progress=dot:mega https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
@@ -55,9 +55,9 @@ jobs:
             ~/ncs/${{ env.SDK_VERSION }}
           key: ${{ steps.cache-sdk-restore.outputs.cache-primary-key }}
 
-      # - name: Build project
-      #   run: |
-      #     ./nrfutil sdk-manager list --all-fields
-      #     export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq -r ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0] + \"/zephyr\"")
-      #     echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
-      #     ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c './zigbee_home --config ./examples/basic/zigbee.yaml firmware --workdir project build'
+      - name: Build project
+        run: |
+          ./nrfutil sdk-manager list --all-fields
+          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq -r ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0] + \"/zephyr\"")
+          echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
+          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c './zigbee_home --config ./examples/basic/zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -16,7 +16,7 @@ jobs:
       # version from downloaded Add On.
       # Though I can confirm that having SDK verion of 2.9.2 works with Toolchain v3.1.0
       ZIGBEE_ADD_ON_VERSION: v1.2.1
-      TOOLCHAIN_VERSION: v2.9.2
+      TOOLCHAIN_VERSION: v3.1.1
       GO_VERSION: '1.24'
       NRFUTIL_VERSION: '8.1.1'
     steps:
@@ -57,8 +57,6 @@ jobs:
         run: |
           ./nrfutil toolchain-manager install --ncs-version ${TOOLCHAIN_VERSION}
           mkdir ~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION}
-          
-          ln -s /lib/x86_64-linux-gnu/libunistring.so.{5.0.0,2}
 
           ./nrfutil toolchain-manager launch --chdir ~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION} --ncs-version ${TOOLCHAIN_VERSION} -- \
           bash -c 'west init -m "http://github.com/nrfconnect/ncs-zigbee" --mr ${ZIGBEE_ADD_ON_VERSION} && \

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -34,6 +34,8 @@ jobs:
         run: ./nrfutil sdk-manager install ${SDK_VERSION}
       - name: Build project
         run: |
+          ./nrfutil sdk-manager list --all-fields
+          ./nrfutil sdk-manager list --json
           export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq '.data.versions[] | select(.version == "${SDK_VERSION}").dirNames[0]')
           echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
           ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c 'printenv && ./zigbee_home --config zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   empty:
     runs-on: ubuntu-latest
+    container: flayer/nordic-sdk:v2.9.2
     env:
       SDK_VERSION: v2.9.2
       # Let zigbee_home know that env is already set up.
@@ -27,14 +28,14 @@ jobs:
         run: | 
           wget --progress=dot:mega https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
           chmod +x nrfutil
-      - name: Install Toolchain and SDK managers
-        run: |
-          ./nrfutil install toolchain-manager sdk-manager
-      - name: Download Toolchain and SDK
-        run: ./nrfutil sdk-manager install ${SDK_VERSION}
+      # - name: Install Toolchain and SDK managers
+      #   run: |
+      #     ./nrfutil install toolchain-manager sdk-manager
+      # - name: Download Toolchain and SDK
+      #   run: ./nrfutil sdk-manager install ${SDK_VERSION}
       - name: Build project
         run: |
           ./nrfutil sdk-manager list --all-fields
-          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0]")/zephyr
+          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq -r ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0] + \"/zephyr\"")
           echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
           ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c './zigbee_home --config zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -61,11 +61,6 @@ jobs:
           ./nrfutil toolchain-manager launch --chdir ~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION} --ncs-version ${TOOLCHAIN_VERSION} -- \
           bash -c 'west init -m "http://github.com/nrfconnect/ncs-zigbee" --mr ${ZIGBEE_ADD_ON_VERSION} && \
           west update -o=--depth=1 -n'
-      - name: List installed toolchains and sdks
-        run: |
-          ./nrfutil -V
-          ./nrfutil toolchain-manager list
-          ./nrfutil sdk-manager list --all-fields
       - name: Cache downloaded SDK
         if: steps.cache-sdk.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -76,6 +71,10 @@ jobs:
             ~/ncs/toolchains
             ~/ncs/zigbee_sdk_${{ env.ZIGBEE_ADD_ON_VERSION }}
           key: ${{ steps.cache-sdk.outputs.cache-primary-key }}
+      - name: List installed toolchains and sdks
+        run: |
+          ./nrfutil -V
+          ./nrfutil toolchain-manager list
 
       - name: Build project
         env:

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -30,11 +30,29 @@ jobs:
       - name: Install Toolchain and SDK managers
         run: |
           ./nrfutil install toolchain-manager sdk-manager
+
+      - name: Restore cached SDK
+        id: cache-sdk-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /root/ncs/toolchains
+            /root/ncs/${SDK_VERSION}
+          key: ${{ runner.os }}-ncs-${SDK_VERSION}
       - name: Download Toolchain and SDK
+        if: steps.cache-sdk.outputs.cache-hit != 'true'
         run: ./nrfutil sdk-manager install ${SDK_VERSION}
+      - name: Cache downloaded SDK
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /root/ncs/toolchains
+            /root/ncs/${SDK_VERSION}
+          key: ${{ steps.cache-sdk-restore.outputs.cache-primary-key }}
+
       - name: Build project
         run: |
           ./nrfutil sdk-manager list --all-fields
           export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq -r ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0] + \"/zephyr\"")
           echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
-          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c './zigbee_home --config zigbee.yaml firmware --workdir project build'
+          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c './zigbee_home --config ./examples/basic/zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -37,17 +37,24 @@ jobs:
         with:
           path: |
             /root/ncs/toolchains
-            /root/ncs/${SDK_VERSION}
-          key: ${{ runner.os }}-ncs-${SDK_VERSION}
+            /root/ncs/${{ env.SDK_VERSION }}
+          key: ${{ runner.os }}-ncs-${{ env.SDK_VERSION }}
       - name: Download Toolchain and SDK
         if: steps.cache-sdk.outputs.cache-hit != 'true'
         run: ./nrfutil sdk-manager install ${SDK_VERSION}
+      - name: Some cache debug
+        run: |
+          echo "U:$(id -u) G:$(id -g)"
+          echo "$(id)"
+          ls -l ~/ncs/toolchains
+          sudo chown -R $(id -u):$(id -g) /root/ncs || true
+
       - name: Cache downloaded SDK
         uses: actions/cache/save@v4
         with:
           path: |
             /root/ncs/toolchains
-            /root/ncs/${SDK_VERSION}
+            /root/ncs/${{ env.SDK_VERSION }}
           key: ${{ steps.cache-sdk-restore.outputs.cache-primary-key }}
 
       - name: Build project

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Build project
         run: |
           ./nrfutil sdk-manager list --all-fields
-          ./nrfutil sdk-manager list --json
-          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0]")
+          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0]")/zephyr
           echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
-          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c 'printenv && ./zigbee_home --config zigbee.yaml firmware --workdir project build'
+          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c './zigbee_home --config zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -73,8 +73,15 @@ jobs:
           key: ${{ steps.cache-sdk.outputs.cache-primary-key }}
       - name: List installed toolchains and sdks
         run: |
+          echo "::group::NRFUtil version"
           ./nrfutil -V
+          echo "::endgroup::"
+          echo "::group::Installed toolchains"
           ./nrfutil toolchain-manager list
+          echo "::endgroup::"
+          echo "::group::Installed SDKs"
+          cd ~/ncs/ && find . -maxdepth 3 -name "VERSION" -exec echo {} \; -exec cat {} \;
+          echo "::endgroup::"
 
       - name: Build project
         env:
@@ -83,4 +90,6 @@ jobs:
         run: |
           export ZEPHYR_BASE=~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION}/zephyr
           echo "Set ZEPHYR_BASE at ${ZEPHYR_BASE}."
+          echo "::group::Build logs"
           ./nrfutil toolchain-manager launch --ncs-version ${TOOLCHAIN_VERSION} -- bash -c './zigbee_home --config ./examples/basic/zigbee.yaml firmware --workdir project build'
+          echo "::endgroup::"

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -36,25 +36,18 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            /root/ncs/toolchains
-            /root/ncs/${{ env.SDK_VERSION }}
+            ${{ env.HOME }}/ncs/toolchains
+            ${{ env.HOME }}/ncs/${{ env.SDK_VERSION }}
           key: ${{ runner.os }}-ncs-${{ env.SDK_VERSION }}
       - name: Download Toolchain and SDK
         if: steps.cache-sdk.outputs.cache-hit != 'true'
         run: ./nrfutil sdk-manager install ${SDK_VERSION}
-      - name: Some cache debug
-        run: |
-          echo "U:$(id -u) G:$(id -g)"
-          echo "$(id)"
-          ls -l ~/ncs/toolchains
-          sudo chown -R $(id -u):$(id -g) /root/ncs || true
-
       - name: Cache downloaded SDK
         uses: actions/cache/save@v4
         with:
           path: |
-            /root/ncs/toolchains
-            /root/ncs/${{ env.SDK_VERSION }}
+            ${{ env.HOME }}/ncs/toolchains
+            ${{ env.HOME }}/ncs/${{ env.SDK_VERSION }}
           key: ${{ steps.cache-sdk-restore.outputs.cache-primary-key }}
 
       - name: Build project

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -25,12 +25,11 @@ jobs:
         run: go build -o zigbee_home ./cmd/zigbee/; chmod +x ./zigbee_home
       - name: Download nrfutil
         run: | 
-          wget --progress=dot:binary https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
+          wget --progress=dot:mega https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
           chmod +x nrfutil
       - name: Install Toolchain and SDK managers
         run: |
-          ./nrfutil install toolchain-manager
-          ./nrfutil install sdk-manager
+          ./nrfutil install toolchain-manager sdk-manager
       - name: Download Toolchain and SDK
         run: ./nrfutil sdk-manager install ${SDK_VERSION}
       - name: Build project

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -9,7 +9,8 @@ concurrency:
 
 jobs:
   empty:
-    runs-on: ghcr.io/zephyrproject-rtos/ci:v0.28.6
+    runs-on: ubuntu-latest
+    container: ghcr.io/zephyrproject-rtos/ci:v0.28.6
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -47,7 +47,7 @@ jobs:
           ./nrfutil toolchain-manager list
           ./nrfutil sdk-manager list --all-fields
       - name: Cache downloaded SDK
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
+        if: steps.cache-sdk-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -9,7 +9,19 @@ concurrency:
 
 jobs:
   empty:
-    runs-on: self-hosted
+    runs-on: ghcr.io/zephyrproject-rtos/ci:v0.28.6
     steps:
-      - name: empty
-        run: echo 'Nothing to see here'
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: go.sum
+      - name: Pull Nordic Zigbee Add on SDK
+        run: | 
+          west init -m "http://github.com/nrfconnect/ncs-zigbee" --mr v1.2.1
+          west update
+      - name: Build executable
+        run: go build -o zigbee_home ./cmd/zigbee/; chmod +x ./zigbee_home
+      - name: Build project
+        run: ./zigbee_home --config zigbee.yaml firmware --workdir project build

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Download Toolchain and SDK
         if: steps.cache-sdk.outputs.cache-hit != 'true'
         run: |
-          ./nrfutil toolchain-manager install ${TOOLCHAIN_VERSION}
+          ./nrfutil toolchain-manager install --ncs-version ${TOOLCHAIN_VERSION}
           mkdir ~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION}
           
           ./nrfutil toolchain-manager launch --chdir ~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION} --ncs-version ${TOOLCHAIN_VERSION} -- \

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -15,14 +15,14 @@ jobs:
       # Let zigbee_home know that env is already set up.
       NO_SETUP_ENV: 1
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-          cache-dependency-path: go.sum
-      - name: Build executable
-        run: go build -o zigbee_home ./cmd/zigbee/; chmod +x ./zigbee_home
+      # - uses: actions/checkout@v4
+      # - name: Set up Go
+      #   uses: actions/setup-go@v5
+      #   with:
+      #     go-version: '1.24'
+      #     cache-dependency-path: go.sum
+      # - name: Build executable
+      #   run: go build -o zigbee_home ./cmd/zigbee/; chmod +x ./zigbee_home
       - name: Download nrfutil
         run: | 
           wget --progress=dot:mega https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
@@ -36,8 +36,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ${{ env.HOME }}/ncs/toolchains
-            ${{ env.HOME }}/ncs/${{ env.SDK_VERSION }}
+            ~/ncs/toolchains
+            ~/ncs/${{ env.SDK_VERSION }}
           key: ${{ runner.os }}-ncs-${{ env.SDK_VERSION }}
       - name: Download Toolchain and SDK
         if: steps.cache-sdk.outputs.cache-hit != 'true'
@@ -46,13 +46,13 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: |
-            ${{ env.HOME }}/ncs/toolchains
-            ${{ env.HOME }}/ncs/${{ env.SDK_VERSION }}
+            ~/ncs/toolchains
+            ~/ncs/${{ env.SDK_VERSION }}
           key: ${{ steps.cache-sdk-restore.outputs.cache-primary-key }}
 
-      - name: Build project
-        run: |
-          ./nrfutil sdk-manager list --all-fields
-          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq -r ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0] + \"/zephyr\"")
-          echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
-          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c './zigbee_home --config ./examples/basic/zigbee.yaml firmware --workdir project build'
+      # - name: Build project
+      #   run: |
+      #     ./nrfutil sdk-manager list --all-fields
+      #     export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq -r ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0] + \"/zephyr\"")
+      #     echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
+      #     ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c './zigbee_home --config ./examples/basic/zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -11,7 +11,12 @@ jobs:
   build_firmware:
     runs-on: ubuntu-latest
     env:
-      SDK_VERSION: v2.9.2
+      # Somehow we should try to keep Add On and Toolchain in sync.
+      # But as we download toolchain before Add On - we can't fetch 
+      # version from downloaded Add On.
+      # Though I can confirm that having SDK verion of 2.9.2 works with Toolchain v3.1.0
+      ZIGBEE_ADD_ON_VERSION: v1.2.1
+      TOOLCHAIN_VERSION: v2.9.2
       GO_VERSION: '1.24'
       NRFUTIL_VERSION: '8.1.1'
     steps:
@@ -31,8 +36,8 @@ jobs:
             ${{ github.workspace }}/nrfutil
             ~/.nrfutil/bin
             ~/ncs/toolchains
-            ~/ncs/${{ env.SDK_VERSION }}
-          key: ${{ runner.os }}-ncs-${{ env.SDK_VERSION }}-nrfutil-${{ env.NRFUTIL_VERSION }}
+            ~/ncs/zigbee_sdk_${{ env.ZIGBEE_ADD_ON_VERSION }}
+          key: ${{ runner.os }}-zigbee-sdk-${{ env.ZIGBEE_ADD_ON_VERSION }}-nrfutil-${{ env.NRFUTIL_VERSION }}
       - name: Download nrfutil
         if: steps.cache-sdk.outputs.cache-hit != 'true'
         env:
@@ -45,11 +50,17 @@ jobs:
       - name: Install Toolchain and SDK managers
         if: steps.cache-sdk.outputs.cache-hit != 'true'
         run: |
-          ./nrfutil install toolchain-manager sdk-manager
+          ./nrfutil install toolchain-manager
           ./nrfutil list
       - name: Download Toolchain and SDK
         if: steps.cache-sdk.outputs.cache-hit != 'true'
-        run: ./nrfutil sdk-manager install ${SDK_VERSION}
+        run: |
+          ./nrfutil toolchain-manager install ${TOOLCHAIN_VERSION}
+          mkdir ~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION}
+          
+          ./nrfutil toolchain-manager launch --chdir ~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION} --ncs-version ${TOOLCHAIN_VERSION} -- \
+          bash -c 'west init -m "http://github.com/nrfconnect/ncs-zigbee" --mr ${ZIGBEE_ADD_ON_VERSION} && \
+          west update -o=--depth=1 -n'
       - name: List installed toolchains and sdks
         run: |
           ./nrfutil -V
@@ -63,7 +74,7 @@ jobs:
             ${{ github.workspace }}/nrfutil
             ~/.nrfutil/bin
             ~/ncs/toolchains
-            ~/ncs/${{ env.SDK_VERSION }}
+            ~/ncs/zigbee_sdk_${{ env.ZIGBEE_ADD_ON_VERSION }}
           key: ${{ steps.cache-sdk.outputs.cache-primary-key }}
 
       - name: Build project
@@ -71,6 +82,6 @@ jobs:
           # Let zigbee_home know that env is already set up.
           NO_SETUP_ENV: 1
         run: |
-          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq -r ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0] + \"/zephyr\"")
+          export ZEPHYR_BASE=~/ncs/zigbee_sdk_${ZIGBEE_ADD_ON_VERSION}/zephyr
           echo "Set ZEPHYR_BASE at ${ZEPHYR_BASE}."
-          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c './zigbee_home --config ./examples/basic/zigbee.yaml firmware --workdir project build'
+          ./nrfutil toolchain-manager launch --ncs-version ${TOOLCHAIN_VERSION} -- bash -c './zigbee_home --config ./examples/basic/zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -36,6 +36,6 @@ jobs:
         run: |
           ./nrfutil sdk-manager list --all-fields
           ./nrfutil sdk-manager list --json
-          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq '.data.versions[] | select(.version == "${SDK_VERSION}").dirNames[0]')
+          export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq ".data.versions[] | select(.version == \"${SDK_VERSION}\").dirNames[0])
           echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
           ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c 'printenv && ./zigbee_home --config zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -39,8 +39,7 @@ jobs:
           BASE_URL: https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/packages/nrfutil
         run: | 
           wget --progress=dot:mega -O nrfutil.tar.gz ${BASE_URL}/nrfutil-x86_64-unknown-linux-gnu-${NRFUTIL_VERSION}.tar.gz
-          tar -tf ./nrfutil.tar.gz
-          tar -xOf ./nrfutil.tar.gz ./nrfutil-x86_64-unknown-linux-gnu-${NRFUTIL_VERSION}/data/bin/nrfutil > nrfutil
+          tar -xOf ./nrfutil.tar.gz nrfutil-x86_64-unknown-linux-gnu-${NRFUTIL_VERSION}/data/bin/nrfutil > nrfutil
           rm ./nrfutil.tar.gz
           chmod +x nrfutil
       - name: Install Toolchain and SDK managers
@@ -51,7 +50,7 @@ jobs:
       - name: Download Toolchain and SDK
         if: steps.cache-sdk.outputs.cache-hit != 'true'
         run: ./nrfutil sdk-manager install ${SDK_VERSION}
-      - name: Verify toolchain and sdk are installed
+      - name: List installed toolchains and sdks
         run: |
           ./nrfutil -V
           ./nrfutil toolchain-manager list

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -10,7 +10,6 @@ concurrency:
 jobs:
   empty:
     runs-on: ubuntu-latest
-    container: flayer/nordic-sdk:v2.9.2
     env:
       SDK_VERSION: v2.9.2
       # Let zigbee_home know that env is already set up.
@@ -28,11 +27,11 @@ jobs:
         run: | 
           wget --progress=dot:mega https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
           chmod +x nrfutil
-      # - name: Install Toolchain and SDK managers
-      #   run: |
-      #     ./nrfutil install toolchain-manager sdk-manager
-      # - name: Download Toolchain and SDK
-      #   run: ./nrfutil sdk-manager install ${SDK_VERSION}
+      - name: Install Toolchain and SDK managers
+        run: |
+          ./nrfutil install toolchain-manager sdk-manager
+      - name: Download Toolchain and SDK
+        run: ./nrfutil sdk-manager install ${SDK_VERSION}
       - name: Build project
         run: |
           ./nrfutil sdk-manager list --all-fields

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -35,4 +35,5 @@ jobs:
       - name: Build project
         run: |
           export ZEPHYR_BASE=$(./nrfutil sdk-manager list --json | jq '.data.versions[] | select(.version == "${SDK_VERSION}").dirNames[0]')
-          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- ./zigbee_home --config zigbee.yaml firmware --workdir project build
+          echo "Found ZEPHYR_BASE at ${ZEPHYR_BASE}."
+          ./nrfutil toolchain-manager launch --ncs-version ${SDK_VERSION} -- bash -c 'printenv && ./zigbee_home --config zigbee.yaml firmware --workdir project build'

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -39,6 +39,7 @@ jobs:
           BASE_URL: https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/packages/nrfutil
         run: | 
           wget --progress=dot:mega -O nrfutil.tar.gz ${BASE_URL}/nrfutil-x86_64-unknown-linux-gnu-${NRFUTIL_VERSION}.tar.gz
+          tar -tf ./nrfutil.tar.gz
           tar -xOf ./nrfutil.tar.gz ./nrfutil-x86_64-unknown-linux-gnu-${NRFUTIL_VERSION}/data/bin/nrfutil > nrfutil
           rm ./nrfutil.tar.gz
           chmod +x nrfutil

--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -42,7 +42,12 @@ jobs:
       - name: Download Toolchain and SDK
         if: steps.cache-sdk.outputs.cache-hit != 'true'
         run: ./nrfutil sdk-manager install ${SDK_VERSION}
+      - name: Verify toolchain and sdk are installed
+        run: |
+          ./nrfutil toolchain-manager list
+          ./nrfutil sdk-manager list --all-fields
       - name: Cache downloaded SDK
+        if: steps.cache-sdk.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 # Dot files are not necessary, unless forced
 # Especially on MacOS..
 .*
+# But not Github's config!
+!.github
 
 # Test builds
 /_*


### PR DESCRIPTION
This is a working example of how to build firmware with nRF toolchain and SDK.

NordicPlayground's [docker image repo](https://github.com/NordicPlayground/nrf-docker) now recommends using Zephyr CI docker image, though it is wildly heavy, resulting in runner [not having enough space](https://github.com/ffenix113/zigbee_home/actions/runs/18881979610/job/53887304532) to extract Zephyr's docker image. Zephyr's image contains a lot of useful add-ons, but not for this project. For example, it contains Rust installed, consuming 1+GB by itself...

Instead, we use `nrfutil` approach and download toolchain, and then download SDK with `west init`.

This results in a much "leaner" image, containing only what is necessary for the build. In combination with Github Actions cache, it can do a setup & firmware build in ~2 minutes.

This workflow still needs to be wired, to be actually useful, but it already can be used to manually build the firmware from some branch's root `zigbee.yaml` configuration.