### PR TITLE
feat: add basic rotary encoder support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # Test builds
 /_*
+/zigbee_*
 
 # Test configurations
 zigbee_*.yaml

--- a/sensor/base/base.go
+++ b/sensor/base/base.go
@@ -1,6 +1,8 @@
 package base
 
 import (
+	"strings"
+
 	"github.com/ffenix113/zigbee_home/types/appconfig"
 	"github.com/ffenix113/zigbee_home/types/devicetree"
 	"github.com/ffenix113/zigbee_home/zcl/cluster"
@@ -21,6 +23,10 @@ type Base struct {
 
 func (b *Base) Label() string {
 	return b.label
+}
+
+func (b *Base) DeviceTreeLabel() string {
+	return strings.ReplaceAll(b.Label(), "_", "-")
 }
 
 func (b *Base) SetLabel(label string) {

--- a/sensor/base/rotary_encoder.go
+++ b/sensor/base/rotary_encoder.go
@@ -1,0 +1,154 @@
+package base
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/ffenix113/zigbee_home/templates/extenders"
+	"github.com/ffenix113/zigbee_home/types"
+	"github.com/ffenix113/zigbee_home/types/appconfig"
+	dt "github.com/ffenix113/zigbee_home/types/devicetree"
+	"github.com/ffenix113/zigbee_home/types/generator"
+	"github.com/ffenix113/zigbee_home/zcl/cluster"
+)
+
+// Rotary encoder will send events for each rotation so that devices,
+// such as lights, can be level-controlled, for example the brightness.
+//
+// Rotary encoder can also optionally have a switch (button).
+// Though currently switch is no supported.
+//
+// TODO: Add an option to count total number of pulses(rotations)
+// instead of emitting after each (debounced) pulse.
+//
+// So instead of sending a "step" command every half a second,
+// it could count all pulses, and send a cumulative "step" command
+// after some period of time, for example 1 second.
+type RotaryEncoder struct {
+	*Base                 `yaml:",inline"`
+	MaxRotationsPerSecond uint8 `yaml:"max_rotations_per_second"`
+	// Resolution optionally defines how many pulses should be registered before reporting the change.
+	//
+	// If rotary encoder is just left/right -
+	// then most probably this value should be left with default value (2).
+	Resolution uint8 `yaml:"resolution"`
+	// Sample time optionally specifies how frequently pins should be polled when first pulse is received.
+	// The lower this value - higher the rotation speed can be used.
+	//
+	// Probably it is not reasonable to set this value to more than 2ms.
+	//
+	// If you notice that a lot of steps are not reported - try lowering this value by 100ms
+	// until you are satisfied with reported counts.
+	SampleTime time.Duration `yaml:"sample_time"`
+
+	Pins struct {
+		A types.PinWithID
+		B types.PinWithID
+
+		SwitchPin types.PinWithID `yaml:"switch_pin"`
+	}
+}
+
+func NewRotaryEncoder() *RotaryEncoder {
+	return &RotaryEncoder{
+		MaxRotationsPerSecond: 2,
+		Resolution:            2,
+		SampleTime:            1500 * time.Microsecond,
+	}
+}
+
+func (*RotaryEncoder) String() string {
+	return "RotaryEncoder"
+}
+
+func (*RotaryEncoder) Template() string {
+	return "sensors/level_control"
+}
+
+func (*RotaryEncoder) CPPComponentType() string {
+	return "LevelControl"
+}
+
+func (o *RotaryEncoder) Clusters() cluster.Clusters {
+	return []cluster.Cluster{
+		cluster.LevelControl{},
+	}
+}
+
+func (*RotaryEncoder) WriteFiles() []generator.WriteFile {
+	return []generator.WriteFile{
+		{
+			FileName:     "types_level_control.hpp",
+			TemplateName: "types_level_control.hpp",
+		},
+		{
+			FileName:     "types_level_control.cpp",
+			TemplateName: "types_level_control.cpp",
+		},
+	}
+}
+
+func (*RotaryEncoder) Includes() []string {
+	return []string{
+		"types_level_control.hpp",
+	}
+}
+
+func (*RotaryEncoder) AppConfig() []appconfig.ConfigValue {
+	return []appconfig.ConfigValue{
+		appconfig.NewValue("CONFIG_GPIO").Required(appconfig.Yes),
+		appconfig.NewValue("CONFIG_INPUT").Required(appconfig.Yes),
+	}
+}
+
+func (e *RotaryEncoder) NeedsDevice() bool {
+	return true
+}
+
+func (o *RotaryEncoder) ApplyOverlay(overlay *dt.DeviceTree) error {
+	resolution := 2
+	if o.Resolution != 0 {
+		resolution = int(o.Resolution)
+	}
+
+	sampleTime := 1500 * time.Microsecond
+	if o.SampleTime != 0 {
+		sampleTime = o.SampleTime
+	}
+
+	root := overlay.FindSpecificNode(dt.SearchByName(dt.NodeNameRoot))
+
+	root.AddNodes(&dt.Node{
+		Name:  o.Label(),
+		Label: o.Label(),
+
+		Properties: []dt.Property{
+			dt.NewProperty(dt.PropertyNameCompatible, dt.Quoted("gpio-qdec")),
+			dt.PropertyStatusEnable,
+			dt.NewProperty("gpios", dt.Array(
+				dt.GPIOPin(o.Pins.A.ToPin()),
+				dt.GPIOPin(o.Pins.B.ToPin()),
+			)),
+			dt.NewProperty("steps-per-period", dt.Angled(dt.String(strconv.Itoa(resolution)))),
+
+			dt.NewProperty("zephyr,axis", dt.Angled(dt.String("INPUT_REL_WHEEL"))),
+			dt.NewProperty("sample-time-us", dt.Angled(dt.String(strconv.Itoa(int(sampleTime.Microseconds()))))),
+			dt.NewProperty("idle-timeout-ms", dt.Angled(dt.String("400"))),
+		},
+	})
+
+	aliases := overlay.FindSpecificNode(dt.SearchByName(dt.NodeNameRoot), dt.SearchByName(dt.NodeNameAliases))
+
+	aliases.AddProperties(dt.NewProperty(o.DeviceTreeLabel(), dt.Label(o.Label())))
+
+	// Currently switch is not supported.
+
+	return nil
+}
+
+func (*RotaryEncoder) Extenders() []generator.Extender {
+	return []generator.Extender{
+		extenders.GPIO{},
+		// extenders.NewLEDs(),
+	}
+}

--- a/templates/src/extenders/sensors/level_control.tpl
+++ b/templates/src/extenders/sensors/level_control.tpl
@@ -1,0 +1,7 @@
+{{ define "top_level" }} {{ end }}
+{{ define "button_changed"}} {{end}}
+{{ define "loop" }} {{end}}
+{{ define "main"}} {{ end}}
+
+{{ define "component_constructor_arguments" }} {{end}}
+{{ define "component_constructor_argument_names" }} {{ .Sensor.MaxRotationsPerSecond}} {{end}}

--- a/templates/src/types.hpp
+++ b/templates/src/types.hpp
@@ -42,7 +42,7 @@ namespace zbhome
             //
             // A component may also have a specific constructor,
             // i.e. to add a device reference, or set min/max values, etc.
-            bool setup();
+            virtual bool setup();
 
         private:
             uint8_t m_endpoint = 0;

--- a/templates/src/types_ias_zone.hpp
+++ b/templates/src/types_ias_zone.hpp
@@ -21,7 +21,7 @@ namespace zbhome
         {
         public:
             IASZone(uint32_t button_bit);
-            bool setup();
+            bool setup() override;
 
         private:
             static void update_zone_status(zb_bufid_t bufid, zb_uint16_t cb_data);

--- a/templates/src/types_level_control.cpp
+++ b/templates/src/types_level_control.cpp
@@ -1,0 +1,108 @@
+#include <zephyr/logging/log.h>
+#include <zephyr/input/input.h>
+
+#include "clusters.hpp"
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+#include <zb_zcl_level_control.h>
+#include <zigbee/zigbee_error_handler.h>
+#ifdef __cplusplus
+}
+#endif
+
+#include <dk_buttons_and_leds.h>
+
+#include "types.hpp"
+#include "types_level_control.hpp"
+#include "types_button_handler.hpp"
+
+LOG_MODULE_REGISTER(level, LOG_LEVEL_DBG);
+
+namespace zbhome
+{
+    namespace components
+    {
+        // A bit of a hack, because we need to match device to levelControl instance.
+        static std::unordered_map<const struct device *, LevelControl *> level_map = {};
+        static const auto level_input_cb = LevelControl::m_input_cb;
+        // This callback will be defined as static block in specific ROM location,
+        // so we can't pass in runtime arguments.
+        INPUT_CALLBACK_DEFINE(nullptr, level_input_cb, nullptr);
+
+        LevelControl::LevelControl(uint8_t max_rotations_per_second) : m_rotation_time(1000 / max_rotations_per_second) {
+                                                                       };
+
+        bool LevelControl::setup()
+        {
+            // This code is not in constructor because device is not yet set at that point.
+            level_map[this->getDevice()] = this;
+
+            return zbhome::types::Component::setup();
+        }
+
+        void LevelControl::m_input_cb(input_event *evt, void *user_data)
+        {
+            if (evt->code != INPUT_REL_WHEEL)
+            {
+                return;
+            }
+
+            LevelControl *level_inst = level_map[evt->dev];
+            // Check if we want to listen to this event.
+            if (level_inst == nullptr)
+            {
+                return;
+            }
+
+            const bool same_direction = (evt->value >= 1) == (bool)level_inst->m_prev_direction;
+            // const uint32_t uptime = k_cycle_get_32();
+            const uint32_t uptime = (uint32_t)k_uptime_get();
+
+            const uint32_t time_diff = uptime - level_inst->m_last_ms;
+            // LOG_DBG("%u, %u, %u", uptime, uptime - level_inst->m_last_ms, level_inst->m_rotation_time);
+            if (same_direction && (time_diff < level_inst->m_rotation_time))
+            {
+                // LOG_DBG("level change skipped %p", level_inst);
+                return;
+            }
+
+            const zb_uint8_t endpoint = level_inst->getEndpoint();
+            LOG_DBG("level change %u: %d", time_diff, evt->value);
+            const zb_uint16_t data = endpoint << 1 | evt->value >= 1;
+
+            level_inst->m_last_ms = uptime;
+            level_inst->m_prev_direction = evt->value >= 1;
+
+            /* Allocate output buffer and send on/off command. */
+            zb_ret_t zb_err_code = zb_buf_get_out_delayed_ext(m_send_step_cmd, data, 0);
+            ZB_ERROR_CHECK(zb_err_code);
+        }
+
+        void LevelControl::m_send_step_cmd(zb_bufid_t bufid, zb_uint16_t cb_data)
+        {
+            // TODO: Probably this function needs to free bufid somewhere,
+            // but I am not sure if it is actually the case.
+            // Would need to double-check.
+
+            // Decode values from the argument.
+            bool direction = cb_data & 1;
+            zb_uint8_t endpoint = cb_data >> 1;
+
+            // zb_zcl_level_control_step_req_t *req;
+
+            const zb_uint8_t addr_ep = ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
+
+            zb_zcl_level_control_step_mode_e step_mode = direction ? ZB_ZCL_LEVEL_CONTROL_STEP_MODE_UP : ZB_ZCL_LEVEL_CONTROL_STEP_MODE_DOWN;
+
+            ZB_ZCL_LEVEL_CONTROL_SEND_STEP_REQ_ZCL8(bufid, addr_ep, 0, 0,
+                                                    endpoint, ZB_AF_HA_PROFILE_ID, ZB_ZCL_DISABLE_DEFAULT_RESPONSE,
+                                                    NULL, step_mode,
+                                                    1, 0, 0, 0);
+
+            // Buffer here should not be freed.
+            // Otherwise it crashes ZBOSS stack (for some reason).
+        };
+    }
+}

--- a/templates/src/types_level_control.hpp
+++ b/templates/src/types_level_control.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/input/input.h>
+#include <zephyr/logging/log.h>
+
+#include "types.hpp"
+
+// For some reason ZB_SCHEDULE_CALLBACK is not defined with current setup,
+// and I can't find a necessary include/config to enable it.
+// So for now - re-define the callback as another callback.
+#define ZB_SCHEDULE_CALLBACK ZB_SCHEDULE_APP_CALLBACK
+
+// LOG_MODULE_DECLARE(app, LOG_LEVEL_INF);
+// LOG_MODULE_REGISTER(ias_zone, LOG_LEVEL_INF);
+
+namespace zbhome
+{
+    namespace components
+    {
+        class LevelControl : public zbhome::types::Component
+        {
+        public:
+            // Currently this component is highly-specialized for rotary encoder use.
+            // Feel free to make it more generic.
+            LevelControl(uint8_t max_rotations_per_second);
+            bool setup() override;
+            // Only for input callback
+            static void m_input_cb(input_event *evt, void *user_data);
+
+        private:
+            static void m_send_step_cmd(zb_bufid_t bufid, zb_uint16_t cb_data);
+
+            // Default value to 2 reotations per second.
+            const uint32_t m_rotation_time = 1000 / 2;
+            uint32_t m_last_ms = 0;
+            bool m_prev_direction = true;
+        };
+    }
+}

--- a/templates/src/zigbee/level_control.c.tpl
+++ b/templates/src/zigbee/level_control.c.tpl
@@ -1,0 +1,15 @@
+{{ define "level_control_attr_list" }}
+// Here we don't need to have exntender, as for now usage is limited
+// to only sending command(s) to server.
+ZB_ZCL_DECLARE_LEVEL_CONTROL_ATTRIB_LIST(
+	{{.Cluster.CVarName}}_{{.Endpoint}}_attr_list,
+	&dev_ctx.{{.Cluster.CVarName}}_{{.Endpoint}}_attrs.current_level,
+	&dev_ctx.{{.Cluster.CVarName}}_{{.Endpoint}}_attrs.remaining_time
+);
+{{end}}
+
+{{ define "level_control_attr_init"}}
+	/* Level control */
+	dev_ctx.{{.Cluster.CVarName}}_{{.Endpoint}}_attrs.current_level = ZB_ZCL_LEVEL_CONTROL_CURRENT_LEVEL_DEFAULT_VALUE;
+    dev_ctx.{{.Cluster.CVarName}}_{{.Endpoint}}_attrs.remaining_time = ZB_ZCL_LEVEL_CONTROL_REMAINING_TIME_DEFAULT_VALUE;
+{{end}}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -56,6 +56,7 @@ var knownClusterTemplates = map[cluster.ID]string{
 	cluster.ID_POWER_CONFIG:              "power_config",
 	cluster.ID_DEVICE_TEMP_CONFIG:        "device_temp_config",
 	cluster.ID_ON_OFF:                    "on_off",
+	cluster.ID_LEVEL_CONTROL:             "level_control",
 	cluster.ID_TEMP_MEASUREMENT:          "temperature",
 	cluster.ID_REL_HUMIDITY_MEASUREMENT:  "water_content",
 	cluster.ID_PRESSURE_MEASUREMENT:      "pressure",

--- a/types/devicetree/property.go
+++ b/types/devicetree/property.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/ffenix113/zigbee_home/types"
 )
 
 var PropertyStatusEnable = NewProperty(PropertyNameStatus, StatusOkay)
@@ -60,6 +62,17 @@ func Quoted(value string) PropertyValue {
 
 func Label(label string) PropertyValue {
 	return rawValue("&" + label)
+}
+
+func GPIOPin(pin types.Pin) PropertyValue {
+	activeState := "(GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)"
+	if pin.Inverted {
+		activeState = "(GPIO_ACTIVE_HIGH | GPIO_PULL_UP)"
+	}
+
+	formatted := fmt.Sprintf("gpio%d %d %s", pin.Port, pin.Pin, activeState)
+
+	return Angled(Label(formatted))
 }
 
 // NrfPSel

--- a/types/pin.go
+++ b/types/pin.go
@@ -10,6 +10,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// TODO: Leave only one type for pin which includes
+// all necessary and optional information
+// and provide unmashaler for it to hande all necessary cases.
+
 var _ yaml.Unmarshaler = (*Pin)(nil)
 
 // PinWithID is similar to Pin,

--- a/types/sensor/known.go
+++ b/types/sensor/known.go
@@ -23,13 +23,8 @@ func fromConstructor(constr any) func() Sensor {
 	return func() Sensor {
 		rVal := reflect.ValueOf(constr)
 
-		numOut := rVal.Type().NumOut()
-		switch {
-		case numOut == 0:
-			panic("constructor must have 1 return value")
-		case numOut > 1:
-			retType := rVal.Type().Out(0)
-			panic(fmt.Sprintf("constructor %q should return exactly 1 value", retType.String()))
+		if numOut := rVal.Type().NumOut(); numOut != 1 {
+			panic(fmt.Sprintf("constructor should return exactly 1 value, but has %d", numOut))
 		}
 
 		ret := rVal.Call(nil)[0]
@@ -43,6 +38,9 @@ var knownSensors = map[string]func() Sensor{
 	"on_off":       fromType[*base.OnOff],
 	"power_config": fromType[*base.PowerConfiguration],
 	"contact":      fromConstructor(base.NewContact),
+
+	"rotary_encoder": fromConstructor(base.NewRotaryEncoder),
+
 	// Later we can just alias this to `soil_moisture`
 	// if `soil_moisture` will not be used otherwise.
 	"soil_moisture_adc": fromType[*base.SoilMoistureADC],

--- a/zcl/cluster/cluster_ids.go
+++ b/zcl/cluster/cluster_ids.go
@@ -64,6 +64,8 @@ func (id ID) ToName() (string, error) {
 		value = "identify"
 	case ID_ON_OFF:
 		value = "on_off"
+	case ID_LEVEL_CONTROL:
+		value = "level_control"
 	case ID_TEMP_MEASUREMENT:
 		value = "temp_measurement"
 	case ID_PRESSURE_MEASUREMENT:
@@ -95,10 +97,11 @@ func (id ID) ToZCL() (string, error) {
 }
 
 const ID_BASIC ID = 0              // Basic cluster identifier.
+const ID_POWER_CONFIG ID = 1       // Device power configration
 const ID_DEVICE_TEMP_CONFIG ID = 2 // Device temperature cluster.
 const ID_IDENTIFY ID = 3           // Identify cluster identifier.
 const ID_ON_OFF ID = 6             // On/Off cluster identifier.
-const ID_POWER_CONFIG ID = 1
+const ID_LEVEL_CONTROL ID = 8      // Level control
 
 /* Measurement and Sensing */
 const ID_TEMP_MEASUREMENT ID = 0x0402          // Temperature measurement

--- a/zcl/cluster/level_control.go
+++ b/zcl/cluster/level_control.go
@@ -1,0 +1,26 @@
+package cluster
+
+var _ Cluster = LevelControl{}
+
+// ZCL 3.10.2
+type LevelControl struct {
+}
+
+func (z LevelControl) ID() ID {
+	return ID_LEVEL_CONTROL
+}
+
+func (LevelControl) CAttrType() string {
+	return "zb_zcl_level_control_attrs_t"
+}
+func (LevelControl) CVarName() string {
+	return "level_control"
+}
+
+func (LevelControl) ReportAttrCount() int {
+	return 0
+}
+
+func (z LevelControl) Side() Side {
+	return Client
+}

--- a/zigbee.yaml
+++ b/zigbee.yaml
@@ -220,3 +220,27 @@ sensors:
   #     oversampling: 4
   #   min_moisture_mv: 730
   #   max_moisture_mv: 430
+  #
+  # Rotary encoder that will provide up/down action.
+  # This example will work if pins A and B are
+  # connected as defined, and pin C is connected to Ground.
+  # 
+  # Please note that you may need to have different 
+  # pin configuration than in this example if you would have
+  # pin C connected to IO voltage.
+  #
+  # Also if the resulting actions are reverted, 
+  # i.e. received event is "down" when scrolling clockwise -
+  # you can just swap A and B pins to fix it.
+  # - type: rotary_encoder
+  #   pins:
+  #     a:
+  #       pin:
+  #         port: 1
+  #         pin: 14
+  #         inverted: true
+  #     b:
+  #       pin:
+  #         port: 1
+  #         pin: 15
+  #         inverted: true


### PR DESCRIPTION
Inspired by IKEA Bilresa with scroll wheel.

Allows using rotary encoder by sending step up/down commands on each step.

Currently it does not implement
switch button on the encoder.

Tested on EC11 encoder, though
others should also work.